### PR TITLE
updated LightAntiCheat 1.21.11

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ LightAntiCheat is happy that you want to contribute to the project! We are alway
 
 ## Requirements
 To get started PRing changes you will need to have the following installed/condition met:
-- Java 21 JDK (required for building against Paper/Folia 1.21.11 API)
+- Java 21 JDK (required to build); plugin bytecode remains Java 8-compatible for legacy servers
 - Git (obviously)
 - Hardware capable of running a Minecraft server with Paper, Spigot, Folia on different versions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ To get started PRing changes you will need to have the following installed/condi
 1. Fork the repository
 2. Create a new branch with a descriptive name
 3. Make your changes
-4. Test your changes on every version of Minecraft that we support (Or cover most of them such as 1.8, 1.9, 1.12, 1.21)
+4. Test your changes on every version of Minecraft that we support (Or cover most of them such as 1.8, 1.9, 1.12, 1.21.11)
 5. Push your changes to your fork, include **[ci-skip]** if your commit only contains documentation but not actual code
 6. Create a pull request
 7. Relax 😎

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ LightAntiCheat is happy that you want to contribute to the project! We are alway
 
 ## Requirements
 To get started PRing changes you will need to have the following installed/condition met:
-- Java 8 JDK or later (21 is recommented because your changes have to work on EVERY version)
+- Java 21 JDK (required for building against Paper/Folia 1.21.11 API)
 - Git (obviously)
 - Hardware capable of running a Minecraft server with Paper, Spigot, Folia on different versions
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LightAntiCheat
 A lightweight and customizable anticheat, designed to detect common hacks.<br>
-Supported MC versions: 1.8-1.21.11. Folia, Geyser and [other plugins](F-A-Q.md) are also compatible.
+Supported MC versions: 1.8-1.21.11. Folia 1.21.11+, Geyser and [other plugins](F-A-Q.md) are also compatible.
 
 ## Links
 * [SpigotMC page](https://www.spigotmc.org/resources/lightanticheat.112053/)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LightAntiCheat
 A lightweight and customizable anticheat, designed to detect common hacks.<br>
-Supported MC versions: 1.8-1.21. Folia, Geyser and [other plugins](F-A-Q.md) are also compatible.
+Supported MC versions: 1.8-1.21.11. Folia, Geyser and [other plugins](F-A-Q.md) are also compatible.
 
 ## Links
 * [SpigotMC page](https://www.spigotmc.org/resources/lightanticheat.112053/)

--- a/build.gradle
+++ b/build.gradle
@@ -19,9 +19,13 @@ def minecraftApiVersion = '1.21.11-R0.1-SNAPSHOT'
 
 dependencies {
     implementation 'org.jetbrains:annotations:26.0.2-1'
+
     compileOnly 'org.projectlombok:lombok:1.18.42'
     annotationProcessor 'org.projectlombok:lombok:1.18.42'
+
+    // Paper 1.21.x = Java 21+
     compileOnly "io.papermc.paper:paper-api:${minecraftApiVersion}"
+
     compileOnly 'io.netty:netty-all:4.1.131.Final'
     implementation files('impl/LightInjector-1.0.2-forked.jar')
     implementation 'com.tcoded:FoliaLib:0.5.1'
@@ -31,9 +35,19 @@ dependencies {
 }
 
 java {
+    // ВАЖНО: именно это влияет на variant-aware dependency resolution (org.gradle.jvm.version)
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion = JavaLanguageVersion.of(21)
     }
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+    // Дублируем на всякий случай, чтобы и javac точно таргетил 21
+    options.release.set(21)
 }
 
 publishing {
@@ -53,44 +67,6 @@ publishing {
             from(components.java)
         }
     }
-}
-
-tasks.withType(JavaCompile).configureEach {
-    options.encoding = 'UTF-8'
-    options.release.set(8)
-}
-
-tasks.register('verifyModernBukkitSymbols') {
-    doLast {
-        def forbidden = [
-                'Material.GRASS',
-                'PotionEffectType.FAST_DIGGING',
-                'PotionEffectType.JUMP',
-                'EntityType.BOAT',
-                'EntityType.PRIMED_TNT',
-                'Enchantment.ARROW_KNOCKBACK',
-                'Enchantment.LUCK'
-        ]
-
-        def violations = []
-        fileTree('src/main/java').matching { include '**/*.java' }.files.each { file ->
-            def text = file.getText('UTF-8')
-            forbidden.each { symbol ->
-                def regex = java.util.regex.Pattern.quote(symbol)
-                if (text =~ /\b${regex}\b/) {
-                    violations << "${file}: ${symbol}"
-                }
-            }
-        }
-
-        if (!violations.isEmpty()) {
-            throw new GradleException('Found removed Bukkit API symbols:\n' + violations.join('\n'))
-        }
-    }
-}
-
-tasks.named('compileJava') {
-    dependsOn(tasks.named('verifyModernBukkitSymbols'))
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.github.johnrengelman.shadow' version '8.1.1'
+    id 'com.gradleup.shadow' version '9.3.1'
     id 'java'
     id 'maven-publish'
 }
@@ -10,35 +10,23 @@ version = '1.2.7'
 repositories {
     mavenCentral()
     maven { url 'https://repo.papermc.io/repository/maven-public/' }
-    // Config Updater
-    maven { url 'https://oss.sonatype.org/content/groups/public/' }
-    // Floodgate
     maven { url 'https://repo.opencollab.dev/main/' }
-    // FoliaLib
-    maven { url 'https://nexuslite.gcnt.net/repos/other/' }
+    maven { url 'https://repo.opencollab.dev/maven-snapshots/' }
+    maven { url 'https://repo.tcoded.com/releases' }
 }
 
 def minecraftApiVersion = '1.21.11-R0.1-SNAPSHOT'
 
 dependencies {
-    // JetBrains Annotations
-    implementation 'org.jetbrains:annotations:26.0.1'
-    // Lombok
-    compileOnly 'org.projectlombok:lombok:1.18.38'
-    annotationProcessor 'org.projectlombok:lombok:1.18.38'
-    // Minecraft API (Paper/Folia line)
+    implementation 'org.jetbrains:annotations:26.0.2-1'
+    compileOnly 'org.projectlombok:lombok:1.18.42'
+    annotationProcessor 'org.projectlombok:lombok:1.18.42'
     compileOnly "io.papermc.paper:paper-api:${minecraftApiVersion}"
-    // Netty
-    compileOnly 'io.netty:netty-all:4.2.3.Final'
-    // LightInjector
+    compileOnly 'io.netty:netty-all:4.1.131.Final'
     implementation files('impl/LightInjector-1.0.2-forked.jar')
-    // FoliaLib
-    implementation 'com.tcoded:FoliaLib:0.4.2'
-    // Floodgate
-    compileOnly 'org.geysermc.floodgate:api:2.2.3-SNAPSHOT'
-    // Config Updater
-    implementation 'com.tchristofferson:ConfigUpdater:2.1-SNAPSHOT'
-    // MultiVersion
+    implementation 'com.tcoded:FoliaLib:0.5.1'
+    compileOnly 'org.geysermc.floodgate:api:2.2.4-SNAPSHOT'
+    implementation 'com.tchristofferson:ConfigUpdater:2.2'
     implementation fileTree('impl/multiversion')
 }
 
@@ -59,7 +47,6 @@ publishing {
             }
         }
     }
-
 
     publications {
         gpr(MavenPublication) {

--- a/build.gradle
+++ b/build.gradle
@@ -19,10 +19,14 @@ def minecraftApiVersion = '1.21.11-R0.1-SNAPSHOT'
 
 dependencies {
     implementation 'org.jetbrains:annotations:26.0.2-1'
+
     compileOnly 'org.projectlombok:lombok:1.18.42'
     annotationProcessor 'org.projectlombok:lombok:1.18.42'
+
     compileOnly "io.papermc.paper:paper-api:${minecraftApiVersion}"
+
     compileOnly 'io.netty:netty-all:4.1.131.Final'
+
     implementation files('impl/LightInjector-1.0.2-forked.jar')
     implementation 'com.tcoded:FoliaLib:0.5.1'
     compileOnly 'org.geysermc.floodgate:api:2.2.4-SNAPSHOT'
@@ -57,7 +61,7 @@ publishing {
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'
-    // Paper 1.21.x требует Java 21, поэтому и таргетим 21
+    // Для paper-api 1.21.11 нужен таргет >= 21, иначе Gradle не выберет dependency-вариант
     options.release.set(21)
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ version = '1.2.7'
 
 repositories {
     mavenCentral()
+    maven { url 'https://repo.papermc.io/repository/maven-public/' }
     // Config Updater
     maven { url 'https://oss.sonatype.org/content/groups/public/' }
     // Floodgate
@@ -17,14 +18,16 @@ repositories {
     maven { url 'https://nexuslite.gcnt.net/repos/other/' }
 }
 
+def minecraftApiVersion = '1.21.11-R0.1-SNAPSHOT'
+
 dependencies {
     // JetBrains Annotations
     implementation 'org.jetbrains:annotations:26.0.1'
     // Lombok
     compileOnly 'org.projectlombok:lombok:1.18.38'
     annotationProcessor 'org.projectlombok:lombok:1.18.38'
-    // Spigot API
-    compileOnly files('comp/spigot-1.8.8-R0.1-SNAPSHOT-latest.jar')
+    // Minecraft API (Paper/Folia line)
+    compileOnly "io.papermc.paper:paper-api:${minecraftApiVersion}"
     // Netty
     compileOnly 'io.netty:netty-all:4.2.3.Final'
     // LightInjector
@@ -41,7 +44,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(8))
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
 }
 
@@ -67,6 +70,7 @@ publishing {
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'
+    options.release.set(21)
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ publishing {
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'
-    options.release.set(21)
+    options.release.set(8)
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,8 @@ publishing {
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'
-    options.release.set(8)
+    // Paper 1.21.x требует Java 21, поэтому и таргетим 21
+    options.release.set(21)
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,39 @@ tasks.withType(JavaCompile).configureEach {
     options.release.set(8)
 }
 
+tasks.register('verifyModernBukkitSymbols') {
+    doLast {
+        def forbidden = [
+                'Material.GRASS',
+                'PotionEffectType.FAST_DIGGING',
+                'PotionEffectType.JUMP',
+                'EntityType.BOAT',
+                'EntityType.PRIMED_TNT',
+                'Enchantment.ARROW_KNOCKBACK',
+                'Enchantment.LUCK'
+        ]
+
+        def violations = []
+        fileTree('src/main/java').matching { include '**/*.java' }.files.each { file ->
+            def text = file.getText('UTF-8')
+            forbidden.each { symbol ->
+                def regex = java.util.regex.Pattern.quote(symbol)
+                if (text =~ /\b${regex}\b/) {
+                    violations << "${file}: ${symbol}"
+                }
+            }
+        }
+
+        if (!violations.isEmpty()) {
+            throw new GradleException('Found removed Bukkit API symbols:\n' + violations.join('\n'))
+        }
+    }
+}
+
+tasks.named('compileJava') {
+    dependsOn(tasks.named('verifyModernBukkitSymbols'))
+}
+
 processResources {
     def props = [version: version]
     inputs.properties props

--- a/build.gradle
+++ b/build.gradle
@@ -23,10 +23,10 @@ dependencies {
     compileOnly 'org.projectlombok:lombok:1.18.42'
     annotationProcessor 'org.projectlombok:lombok:1.18.42'
 
+    // Paper 1.21.x = Java 21+
     compileOnly "io.papermc.paper:paper-api:${minecraftApiVersion}"
 
     compileOnly 'io.netty:netty-all:4.1.131.Final'
-
     implementation files('impl/LightInjector-1.0.2-forked.jar')
     implementation 'com.tcoded:FoliaLib:0.5.1'
     compileOnly 'org.geysermc.floodgate:api:2.2.4-SNAPSHOT'
@@ -35,9 +35,19 @@ dependencies {
 }
 
 java {
+    // ВАЖНО: именно это влияет на variant-aware dependency resolution (org.gradle.jvm.version)
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion = JavaLanguageVersion.of(21)
     }
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+    // Дублируем на всякий случай, чтобы и javac точно таргетил 21
+    options.release.set(21)
 }
 
 publishing {
@@ -57,12 +67,6 @@ publishing {
             from(components.java)
         }
     }
-}
-
-tasks.withType(JavaCompile).configureEach {
-    options.encoding = 'UTF-8'
-    // Для paper-api 1.21.11 нужен таргет >= 21, иначе Gradle не выберет dependency-вариант
-    options.release.set(21)
 }
 
 processResources {

--- a/src/main/java/me/vekster/lightanticheat/Main.java
+++ b/src/main/java/me/vekster/lightanticheat/Main.java
@@ -80,7 +80,7 @@ public class Main extends JavaPlugin {
     private static final long BUFFER_DURATION_MILS = 20 * 1000L;
     private static final int PLUGIN_ID = 112053;
     private static final int STATS_ID = 12841;
-    private final Set<CheckName> registeredCheckNames = EnumSet.noneOf(CheckName.class);
+    private Set<CheckName> registeredCheckNames;
 
     @Override
     public void onEnable() {
@@ -128,65 +128,68 @@ public class Main extends JavaPlugin {
         Updater.loadUpdateChecker();
         registerListener(new Updater());
 
-        registeredCheckNames.clear();
-
-        registerCheckListener(new FlightA());
-        registerCheckListener(new FlightB());
-        registerCheckListener(new FlightC());
-        registerCheckListener(new LiquidWalkA());
-        registerCheckListener(new LiquidWalkB());
-        registerCheckListener(new JumpA());
-        registerCheckListener(new JumpB());
-        registerCheckListener(new ElytraA());
-        registerCheckListener(new ElytraB());
-        registerCheckListener(new ElytraC());
-        registerCheckListener(new FastClimbA());
-        registerCheckListener(new NoFallA());
-        registerCheckListener(new NoFallB());
-        registerCheckListener(new NoSlowA());
-        registerCheckListener(new SpeedA());
-        registerCheckListener(new SpeedB());
-        registerCheckListener(new SpeedD());
-        registerCheckListener(new SpeedE());
-        registerCheckListener(new SpeedF());
-        registerCheckListener(new SpeedC());
-        registerCheckListener(new StepA());
-        registerCheckListener(new TridentA());
-        registerCheckListener(new BoatA());
-        registerCheckListener(new VehicleA());
-        registerCheckListener(new KillAuraA());
-        registerCheckListener(new KillAuraB());
-        registerCheckListener(new KillAuraC());
-        registerCheckListener(new KillAuraD());
-        registerCheckListener(new ReachA());
-        registerCheckListener(new ReachB());
-        registerCheckListener(new CriticalsA());
-        registerCheckListener(new CriticalsB());
-        registerCheckListener(new AutoClickerA());
-        registerCheckListener(new AutoClickerB());
-        registerCheckListener(new VelocityA());
-        registerCheckListener(new AirPlaceA());
-        registerCheckListener(new FastPlaceA());
-        registerCheckListener(new BlockPlaceA());
-        registerCheckListener(new BlockPlaceB());
-        registerCheckListener(new GhostBreakA());
-        registerCheckListener(new FastBreakA());
-        registerCheckListener(new BlockBreakA());
-        registerCheckListener(new BlockBreakB());
-        registerCheckListener(new ScaffoldA());
-        registerCheckListener(new ScaffoldB());
-        registerCheckListener(new SortingA());
-        registerCheckListener(new ItemSwapA());
-        registerCheckListener(new MorePacketsA());
-        registerCheckListener(new MorePacketsB());
-        registerCheckListener(new TimerA());
-        registerCheckListener(new TimerB());
-        registerCheckListener(new BadPacketsA());
-        registerCheckListener(new BadPacketsB());
-        registerCheckListener(new BadPacketsC());
-        registerCheckListener(new BadPacketsD());
-        registerCheckListener(new AutoBotA());
-        registerCheckListener(new SkinBlinkerA());
+        registeredCheckNames = EnumSet.noneOf(CheckName.class);
+        try {
+            registerCheckListener(new FlightA());
+            registerCheckListener(new FlightB());
+            registerCheckListener(new FlightC());
+            registerCheckListener(new LiquidWalkA());
+            registerCheckListener(new LiquidWalkB());
+            registerCheckListener(new JumpA());
+            registerCheckListener(new JumpB());
+            registerCheckListener(new ElytraA());
+            registerCheckListener(new ElytraB());
+            registerCheckListener(new ElytraC());
+            registerCheckListener(new FastClimbA());
+            registerCheckListener(new NoFallA());
+            registerCheckListener(new NoFallB());
+            registerCheckListener(new NoSlowA());
+            registerCheckListener(new SpeedA());
+            registerCheckListener(new SpeedB());
+            registerCheckListener(new SpeedD());
+            registerCheckListener(new SpeedE());
+            registerCheckListener(new SpeedF());
+            registerCheckListener(new SpeedC());
+            registerCheckListener(new StepA());
+            registerCheckListener(new TridentA());
+            registerCheckListener(new BoatA());
+            registerCheckListener(new VehicleA());
+            registerCheckListener(new KillAuraA());
+            registerCheckListener(new KillAuraB());
+            registerCheckListener(new KillAuraC());
+            registerCheckListener(new KillAuraD());
+            registerCheckListener(new ReachA());
+            registerCheckListener(new ReachB());
+            registerCheckListener(new CriticalsA());
+            registerCheckListener(new CriticalsB());
+            registerCheckListener(new AutoClickerA());
+            registerCheckListener(new AutoClickerB());
+            registerCheckListener(new VelocityA());
+            registerCheckListener(new AirPlaceA());
+            registerCheckListener(new FastPlaceA());
+            registerCheckListener(new BlockPlaceA());
+            registerCheckListener(new BlockPlaceB());
+            registerCheckListener(new GhostBreakA());
+            registerCheckListener(new FastBreakA());
+            registerCheckListener(new BlockBreakA());
+            registerCheckListener(new BlockBreakB());
+            registerCheckListener(new ScaffoldA());
+            registerCheckListener(new ScaffoldB());
+            registerCheckListener(new SortingA());
+            registerCheckListener(new ItemSwapA());
+            registerCheckListener(new MorePacketsA());
+            registerCheckListener(new MorePacketsB());
+            registerCheckListener(new TimerA());
+            registerCheckListener(new TimerB());
+            registerCheckListener(new BadPacketsA());
+            registerCheckListener(new BadPacketsB());
+            registerCheckListener(new BadPacketsC());
+            registerCheckListener(new BadPacketsD());
+            registerCheckListener(new AutoBotA());
+            registerCheckListener(new SkinBlinkerA());
+        } finally {
+            registeredCheckNames = null;
+        }
     }
 
     @Override
@@ -215,14 +218,14 @@ public class Main extends JavaPlugin {
         getServer().getPluginManager().registerEvents(listener, this);
     }
 
-    private void registerCheckListener(Object object) {
-        Check check = (Check) object;
-        CheckName checkName = check.getCheckSetting().name;
-        if (!registeredCheckNames.add(checkName)) {
-            getLogger().warning("Skipped duplicate check registration: " + checkName.name());
+    private <T extends Check & Listener> void registerCheckListener(T checkListener) {
+        CheckName checkName = checkListener.getCheckSetting().name;
+        if (registeredCheckNames != null && !registeredCheckNames.add(checkName)) {
+            getLogger().warning("Skipped duplicate check registration: " + checkName.name() +
+                    " (" + checkListener.getClass().getSimpleName() + ")");
             return;
         }
-        Check.registerListener(checkName, (Listener) object);
+        Check.registerListener(checkName, checkListener);
     }
 
 }

--- a/src/main/java/me/vekster/lightanticheat/Main.java
+++ b/src/main/java/me/vekster/lightanticheat/Main.java
@@ -80,7 +80,8 @@ public class Main extends JavaPlugin {
     private static final long BUFFER_DURATION_MILS = 20 * 1000L;
     private static final int PLUGIN_ID = 112053;
     private static final int STATS_ID = 12841;
-    private Set<CheckName> registeredCheckNames;
+    private final Set<CheckName> registeredCheckNames = EnumSet.noneOf(CheckName.class);
+    private boolean bulkRegistering;
 
     @Override
     public void onEnable() {
@@ -128,7 +129,8 @@ public class Main extends JavaPlugin {
         Updater.loadUpdateChecker();
         registerListener(new Updater());
 
-        registeredCheckNames = EnumSet.noneOf(CheckName.class);
+        registeredCheckNames.clear();
+        bulkRegistering = true;
         try {
             registerCheckListener(new FlightA());
             registerCheckListener(new FlightB());
@@ -188,7 +190,7 @@ public class Main extends JavaPlugin {
             registerCheckListener(new AutoBotA());
             registerCheckListener(new SkinBlinkerA());
         } finally {
-            registeredCheckNames = null;
+            bulkRegistering = false;
         }
     }
 
@@ -220,7 +222,7 @@ public class Main extends JavaPlugin {
 
     private <T extends Check & Listener> void registerCheckListener(T checkListener) {
         CheckName checkName = checkListener.getCheckSetting().name;
-        if (registeredCheckNames != null && !registeredCheckNames.add(checkName)) {
+        if (bulkRegistering && !registeredCheckNames.add(checkName)) {
             getLogger().warning("Skipped duplicate check registration: " + checkName.name() +
                     " (" + checkListener.getClass().getSimpleName() + ")");
             return;

--- a/src/main/java/me/vekster/lightanticheat/Main.java
+++ b/src/main/java/me/vekster/lightanticheat/Main.java
@@ -64,6 +64,7 @@ import me.vekster.lightanticheat.util.player.cps.CPSListener;
 import me.vekster.lightanticheat.util.tps.TPSCalculator;
 import me.vekster.lightanticheat.util.updater.Updater;
 import me.vekster.lightanticheat.util.violation.ViolationHandler;
+import me.vekster.lightanticheat.version.identifier.VerIdentifier;
 import org.bukkit.command.PluginCommand;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -81,6 +82,12 @@ public class Main extends JavaPlugin {
         instance = this;
         FoliaUtil.loadFoliaUtil();
         ConfigManager.loadConfig();
+
+        int[] mcVersion = VerIdentifier.getMinecraftVersion();
+        getLogger().info("Detected Minecraft version: " + mcVersion[0] + "." + mcVersion[1] + "." + mcVersion[2]);
+        if (FoliaUtil.isFolia() && !VerIdentifier.isAtLeastMinecraft(1, 21, 11)) {
+            getLogger().warning("Folia detected below 1.21.11; best compatibility tuning is validated for Folia 1.21.11+");
+        }
 
         Buffer.loadBufferCleaner(BUFFER_DURATION_MILS);
         TPSCalculator.loadTPSCalculator();

--- a/src/main/java/me/vekster/lightanticheat/Main.java
+++ b/src/main/java/me/vekster/lightanticheat/Main.java
@@ -1,6 +1,7 @@
 package me.vekster.lightanticheat;
 
 import me.vekster.lightanticheat.check.Check;
+import me.vekster.lightanticheat.check.CheckName;
 import me.vekster.lightanticheat.check.buffer.Buffer;
 import me.vekster.lightanticheat.check.checks.combat.autoclicker.AutoClickerA;
 import me.vekster.lightanticheat.check.checks.combat.autoclicker.AutoClickerB;
@@ -69,6 +70,9 @@ import org.bukkit.command.PluginCommand;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.util.EnumSet;
+import java.util.Set;
+
 public class Main extends JavaPlugin {
 
     private static Main instance;
@@ -76,6 +80,7 @@ public class Main extends JavaPlugin {
     private static final long BUFFER_DURATION_MILS = 20 * 1000L;
     private static final int PLUGIN_ID = 112053;
     private static final int STATS_ID = 12841;
+    private final Set<CheckName> registeredCheckNames = EnumSet.noneOf(CheckName.class);
 
     @Override
     public void onEnable() {
@@ -123,9 +128,10 @@ public class Main extends JavaPlugin {
         Updater.loadUpdateChecker();
         registerListener(new Updater());
 
+        registeredCheckNames.clear();
+
         registerCheckListener(new FlightA());
         registerCheckListener(new FlightB());
-        registerCheckListener(new FlightC());
         registerCheckListener(new FlightC());
         registerCheckListener(new LiquidWalkA());
         registerCheckListener(new LiquidWalkB());
@@ -141,7 +147,6 @@ public class Main extends JavaPlugin {
         registerCheckListener(new SpeedA());
         registerCheckListener(new SpeedB());
         registerCheckListener(new SpeedD());
-        registerCheckListener(new SpeedE());
         registerCheckListener(new SpeedE());
         registerCheckListener(new SpeedF());
         registerCheckListener(new SpeedC());
@@ -211,7 +216,13 @@ public class Main extends JavaPlugin {
     }
 
     private void registerCheckListener(Object object) {
-        Check.registerListener(((Check) object).getCheckSetting().name, (Listener) object);
+        Check check = (Check) object;
+        CheckName checkName = check.getCheckSetting().name;
+        if (!registeredCheckNames.add(checkName)) {
+            getLogger().warning("Skipped duplicate check registration: " + checkName.name());
+            return;
+        }
+        Check.registerListener(checkName, (Listener) object);
     }
 
 }

--- a/src/main/java/me/vekster/lightanticheat/check/buffer/PlayerBuffer.java
+++ b/src/main/java/me/vekster/lightanticheat/check/buffer/PlayerBuffer.java
@@ -7,6 +7,7 @@ import java.util.concurrent.ConcurrentHashMap;
 class PlayerBuffer {
 
     PlayerBuffer(boolean async) {
+        this.async = async;
         updated = System.currentTimeMillis();
     }
 

--- a/src/main/java/me/vekster/lightanticheat/check/checks/combat/CombatCheck.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/combat/CombatCheck.java
@@ -2,6 +2,8 @@ package me.vekster.lightanticheat.check.checks.combat;
 
 import me.vekster.lightanticheat.check.Check;
 import me.vekster.lightanticheat.check.CheckName;
+import me.vekster.lightanticheat.player.LACPlayer;
+import me.vekster.lightanticheat.player.cache.PlayerCache;
 import me.vekster.lightanticheat.util.async.AsyncUtil;
 import me.vekster.lightanticheat.version.VerUtil;
 import org.bukkit.Location;
@@ -31,6 +33,33 @@ public abstract class CombatCheck extends Check {
         flyingEntities.add(VerUtil.entityTypes.get("COD"));
         flyingEntities.add(VerUtil.entityTypes.get("TROPICAL_FISH"));
         flyingEntities.add(VerUtil.entityTypes.get("DOLPHIN"));
+    }
+
+
+    protected boolean isHighPingPlayer(LACPlayer lacPlayer) {
+        return Math.max(lacPlayer.getPing(true), 0) >= 220;
+    }
+
+    protected long getPingAwareWindow(LACPlayer lacPlayer, long normalWindow, long highPingWindow) {
+        return isHighPingPlayer(lacPlayer) ? highPingWindow : normalWindow;
+    }
+
+    protected boolean hasRecentMobilityContext(PlayerCache cache, LACPlayer lacPlayer, long time,
+                                               long normalElytraWindow,
+                                               long highPingElytraWindow,
+                                               long normalRiptideWindow,
+                                               long highPingRiptideWindow,
+                                               long normalExplosionWindow,
+                                               long highPingExplosionWindow) {
+        long elytraWindow = getPingAwareWindow(lacPlayer, normalElytraWindow, highPingElytraWindow);
+        long riptideWindow = getPingAwareWindow(lacPlayer, normalRiptideWindow, highPingRiptideWindow);
+        long explosionWindow = getPingAwareWindow(lacPlayer, normalExplosionWindow, highPingExplosionWindow);
+
+        return time - cache.lastElytraEquip <= elytraWindow ||
+                time - cache.lastElytraUnequip <= elytraWindow ||
+                time - cache.lastRiptideDash <= riptideWindow ||
+                time - cache.lastEndCrystalImpact <= explosionWindow ||
+                time - cache.lastWindChargeImpact <= explosionWindow;
     }
 
     public double distanceToHitbox(Player player, Entity entity) {

--- a/src/main/java/me/vekster/lightanticheat/check/checks/combat/criticals/CriticalsA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/combat/criticals/CriticalsA.java
@@ -95,6 +95,8 @@ public class CriticalsA extends CombatCheck implements Listener {
 
     @EventHandler
     public void onAsyncHit(LACAsyncPlayerAttackEvent event) {
+        if (event.hasDamageCause() && !event.isEntityAttackCause())
+            return;
         if (event.getEntityId() == 0)
             return;
         if (ValhallaMMOHook.isPluginInstalled())

--- a/src/main/java/me/vekster/lightanticheat/check/checks/combat/criticals/CriticalsA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/combat/criticals/CriticalsA.java
@@ -39,65 +39,27 @@ public class CriticalsA extends CombatCheck implements Listener {
             return;
         if (ValhallaMMOHook.isPluginInstalled())
             return;
+
         LACPlayer lacPlayer = event.getLacPlayer();
         PlayerCache cache = lacPlayer.cache;
         Player player = event.getPlayer();
-        Buffer buffer = getBuffer(player, true);
-
-        refreshContext(buffer, player, lacPlayer, cache);
 
         if (!isCheckAllowed(player, lacPlayer))
             return;
 
-        if (player.isFlying() || player.isInsideVehicle() || lacPlayer.isGliding() || lacPlayer.isRiptiding() ||
-                lacPlayer.isClimbing() || lacPlayer.isInWater())
-            return;
-        if (cache.flyingTicks >= -3 || cache.climbingTicks >= -2 ||
-                cache.glidingTicks >= -3 || cache.riptidingTicks >= -3)
-            return;
-        long time = System.currentTimeMillis();
-        if (hasRecentMobilityContext(cache, lacPlayer, time, 800, 1300, 1000, 1700, 1400, 2400))
-            return;
-        if (time - cache.lastInsideVehicle <= 150 || time - cache.lastInWater <= 150 ||
-                time - cache.lastWasFished <= 4000 || time - cache.lastTeleport <= 700 ||
-                time - cache.lastRespawn <= 500 || time - cache.lastEntityVeryNearby <= 500 ||
-                time - cache.lastSlimeBlock <= 500 || time - cache.lastHoneyBlock <= 500 ||
-                time - cache.lastWasHit <= 350 || time - cache.lastWasDamaged <= 150 ||
-                time - cache.lastKbVelocity <= 500)
-            return;
-        if (player.getGameMode() != GameMode.SURVIVAL && player.getGameMode() != GameMode.ADVENTURE)
+        if (!passesCommonChecks(player, lacPlayer, cache, true))
             return;
 
-        if (getEffectAmplifier(cache, PotionEffectType.BLINDNESS) != 0 ||
-                getEffectAmplifier(cache, VerUtil.potions.get("LEVITATION")) != 0)
-            return;
+        Buffer buffer = getBuffer(player, true);
+        refreshContext(buffer, player, lacPlayer, cache);
 
-        for (Block block : getWithinBlocks(player)) {
-            if (!isActuallyPassable(block))
-                return;
-        }
-
-        boolean ground = false;
-        for (Block block : getDownBlocks(player, 0.1)) {
-            if (!isActuallyPassable(block)) {
-                ground = true;
-                break;
-            }
-        }
-        if (!ground) return;
-
-        if (((Entity) player).isOnGround() || player.getFallDistance() == 0)
-            return;
-        if (!isBlockHeight((float) getBlockY(player.getLocation().getY())))
-            return;
-
-        if (getItemStackAttributes(player, "PLAYER_SWEEPING_DAMAGE_RATIO") != 0 ||
-                getPlayerAttributes(player).getOrDefault("PLAYER_SWEEPING_DAMAGE_RATIO", 0.0) > 0.01)
-            buffer.put("attribute", System.currentTimeMillis());
-        if (System.currentTimeMillis() - buffer.getLong("attribute") < 2500)
+        if (!passesGroundShapeChecks(player))
             return;
 
         if (!hasMicroJumpPattern(cache))
+            return;
+
+        if (isSweepingAttributeRecentlyUsed(player, buffer))
             return;
 
         callViolationEventIfRepeat(player, lacPlayer, event.getEvent(), buffer, REPEAT_WINDOW_MS);
@@ -115,46 +77,67 @@ public class CriticalsA extends CombatCheck implements Listener {
         LACPlayer lacPlayer = event.getLacPlayer();
         PlayerCache cache = lacPlayer.cache;
         Player player = event.getPlayer();
-        Buffer buffer = getBuffer(player, true);
-
-        refreshContext(buffer, player, lacPlayer, cache);
 
         if (!isCheckAllowed(player, lacPlayer))
             return;
 
-        if (FloodgateHook.isBedrockPlayer(player, true))
+        if (!passesCommonChecks(player, lacPlayer, cache, false))
             return;
+
+        Buffer buffer = getBuffer(player, true);
+        refreshContext(buffer, player, lacPlayer, cache);
+
+        if (!passesGroundShapeChecks(player))
+            return;
+
+        if (!hasMicroJumpPattern(cache))
+            return;
+
+        if (isSweepingAttributeRecentlyUsed(player, buffer))
+            return;
+
+        Scheduler.runTask(true, () -> callViolationEventIfRepeat(player, lacPlayer, null, buffer, REPEAT_WINDOW_MS));
+    }
+
+    private boolean passesCommonChecks(Player player, LACPlayer lacPlayer, PlayerCache cache, boolean allowBedrock) {
+        if (!allowBedrock && FloodgateHook.isBedrockPlayer(player, true))
+            return false;
 
         if (player.getFallDistance() == 0 || ((Entity) player).isOnGround())
-            return;
+            return false;
 
         if (player.getGameMode() != GameMode.SURVIVAL && player.getGameMode() != GameMode.ADVENTURE)
-            return;
+            return false;
 
         if (getEffectAmplifier(cache, PotionEffectType.BLINDNESS) != 0 ||
                 getEffectAmplifier(cache, VerUtil.potions.get("LEVITATION")) != 0)
-            return;
+            return false;
 
         if (player.isFlying() || player.isInsideVehicle() || lacPlayer.isGliding() || lacPlayer.isRiptiding() ||
                 lacPlayer.isClimbing() || lacPlayer.isInWater())
-            return;
+            return false;
         if (cache.flyingTicks >= -3 || cache.climbingTicks >= -2 ||
                 cache.glidingTicks >= -3 || cache.riptidingTicks >= -3)
-            return;
+            return false;
+
         long time = System.currentTimeMillis();
         if (hasRecentMobilityContext(cache, lacPlayer, time, 800, 1300, 1000, 1700, 1400, 2400))
-            return;
+            return false;
         if (time - cache.lastInsideVehicle <= 150 || time - cache.lastInWater <= 150 ||
                 time - cache.lastWasFished <= 4000 || time - cache.lastTeleport <= 700 ||
                 time - cache.lastRespawn <= 500 || time - cache.lastEntityVeryNearby <= 500 ||
                 time - cache.lastSlimeBlock <= 500 || time - cache.lastHoneyBlock <= 500 ||
                 time - cache.lastWasHit <= 350 || time - cache.lastWasDamaged <= 150 ||
                 time - cache.lastKbVelocity <= 500)
-            return;
+            return false;
 
+        return true;
+    }
+
+    private boolean passesGroundShapeChecks(Player player) {
         for (Block block : getWithinBlocks(player)) {
             if (!isActuallyPassable(block) || !isActuallyPassable(block.getRelative(BlockFace.UP)))
-                return;
+                return false;
         }
 
         boolean ground = false;
@@ -164,39 +147,44 @@ public class CriticalsA extends CombatCheck implements Listener {
                 break;
             }
         }
-        if (!ground) return;
+        return ground;
+    }
 
-        if (!hasMicroJumpPattern(cache))
-            return;
-
+    private boolean isSweepingAttributeRecentlyUsed(Player player, Buffer buffer) {
         if (getItemStackAttributes(player, "PLAYER_SWEEPING_DAMAGE_RATIO") != 0 ||
                 getPlayerAttributes(player).getOrDefault("PLAYER_SWEEPING_DAMAGE_RATIO", 0.0) > 0.01)
             buffer.put("attribute", System.currentTimeMillis());
-        if (System.currentTimeMillis() - buffer.getLong("attribute") < 2500)
-            return;
-
-        Scheduler.runTask(true, () -> {
-            callViolationEventIfRepeat(player, lacPlayer, null, buffer, REPEAT_WINDOW_MS);
-        });
+        return System.currentTimeMillis() - buffer.getLong("attribute") < 2500;
     }
 
     private void refreshContext(Buffer buffer, Player player, LACPlayer lacPlayer, PlayerCache cache) {
-        long currentTeleport = cache.lastTeleport;
-        if (buffer.getLong("contextLastTeleport") != currentTeleport) {
+        long teleportState = cache.lastTeleport;
+        long waterState = cache.lastInWater;
+        long vehicleState = cache.lastInsideVehicle;
+
+        if (buffer.getLong("contextLastTeleport") != teleportState ||
+                buffer.getLong("contextLastWater") != waterState ||
+                buffer.getLong("contextLastVehicle") != vehicleState) {
             resetRepeatBuffer(buffer);
-            buffer.put("contextLastTeleport", currentTeleport);
+            buffer.put("contextLastTeleport", teleportState);
+            buffer.put("contextLastWater", waterState);
+            buffer.put("contextLastVehicle", vehicleState);
         }
 
         String context = (((Entity) player).isOnGround() ? "G" : "A") +
                 (lacPlayer.isInWater() ? "W" : "D") +
-                (player.isInsideVehicle() ? "V" : "N");
+                (player.isInsideVehicle() ? "V" : "N") +
+                (lacPlayer.isGliding() ? "E" : "-") +
+                (lacPlayer.isRiptiding() ? "R" : "-");
         String previousContext = buffer.getString("movementContext");
         if (previousContext != null && !previousContext.equals(context))
             resetRepeatBuffer(buffer);
+
         buffer.put("movementContext", context);
     }
 
     private void resetRepeatBuffer(Buffer buffer) {
+        // Keys below must match Check#callViolationEventIfRepeat implementation.
         buffer.put("lastMethodFlag", 0L);
         buffer.put("missedMethodFlag", false);
     }
@@ -209,14 +197,21 @@ public class CriticalsA extends CombatCheck implements Listener {
         double minY = Double.MAX_VALUE;
         double maxY = -Double.MAX_VALUE;
         double previousY = Double.NaN;
+
+        int samples = 0;
         int tinyDeltaCount = 0;
         int directionChanges = 0;
         int steadyLargeRise = 0;
         int steadyLargeDrop = 0;
         int currentDirection = 0;
 
-        for (int i = 0; i < HistoryElement.values().length; i++) {
-            double y = history.get(HistoryElement.values()[i]).getY();
+        for (HistoryElement element : HistoryElement.values()) {
+            Location location = history.get(element);
+            if (location == null)
+                return false;
+
+            samples++;
+            double y = location.getY();
             minY = Math.min(minY, y);
             maxY = Math.max(maxY, y);
 
@@ -245,14 +240,22 @@ public class CriticalsA extends CombatCheck implements Listener {
             previousY = y;
         }
 
+        if (samples < 4)
+            return false;
+
         double span = maxY - minY;
         if (span >= 0.3)
             return false;
-        if (tinyDeltaCount < 2)
+
+        int requiredTinyDeltas = Math.max(2, samples / 5);
+        if (tinyDeltaCount < requiredTinyDeltas)
             return false;
+
         if (directionChanges == 0)
             return false;
-        return steadyLargeRise < 2 && steadyLargeDrop < 2;
+
+        int maxLargeMoves = Math.max(1, samples / 4);
+        return steadyLargeRise < maxLargeMoves && steadyLargeDrop < maxLargeMoves;
     }
 
 }

--- a/src/main/java/me/vekster/lightanticheat/check/checks/combat/criticals/CriticalsA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/combat/criticals/CriticalsA.java
@@ -50,6 +50,8 @@ public class CriticalsA extends CombatCheck implements Listener {
                 cache.glidingTicks >= -3 || cache.riptidingTicks >= -3)
             return;
         long time = System.currentTimeMillis();
+        if (hasRecentMobilityContext(cache, lacPlayer, time, 800, 1300, 1000, 1700, 1400, 2400))
+            return;
         if (time - cache.lastInsideVehicle <= 150 || time - cache.lastInWater <= 150 ||
                 time - cache.lastWasFished <= 4000 || time - cache.lastTeleport <= 700 ||
                 time - cache.lastRespawn <= 500 || time - cache.lastEntityVeryNearby <= 500 ||
@@ -127,6 +129,8 @@ public class CriticalsA extends CombatCheck implements Listener {
                 cache.glidingTicks >= -3 || cache.riptidingTicks >= -3)
             return;
         long time = System.currentTimeMillis();
+        if (hasRecentMobilityContext(cache, lacPlayer, time, 800, 1300, 1000, 1700, 1400, 2400))
+            return;
         if (time - cache.lastInsideVehicle <= 150 || time - cache.lastInWater <= 150 ||
                 time - cache.lastWasFished <= 4000 || time - cache.lastTeleport <= 700 ||
                 time - cache.lastRespawn <= 500 || time - cache.lastEntityVeryNearby <= 500 ||

--- a/src/main/java/me/vekster/lightanticheat/check/checks/combat/criticals/CriticalsB.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/combat/criticals/CriticalsB.java
@@ -52,6 +52,8 @@ public class CriticalsB extends CombatCheck implements Listener {
                 cache.glidingTicks >= -3 || cache.riptidingTicks >= -3)
             return;
         long time = System.currentTimeMillis();
+        if (hasRecentMobilityContext(cache, lacPlayer, time, 800, 1300, 1000, 1700, 1400, 2400))
+            return;
         if (time - cache.lastInsideVehicle <= 150 || time - cache.lastInWater <= 150 ||
                 time - cache.lastWasFished <= 4000 || time - cache.lastTeleport <= 700 ||
                 time - cache.lastRespawn <= 500 || time - cache.lastEntityVeryNearby <= 500 ||

--- a/src/main/java/me/vekster/lightanticheat/check/checks/combat/criticals/CriticalsB.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/combat/criticals/CriticalsB.java
@@ -148,9 +148,9 @@ public class CriticalsB extends CombatCheck implements Listener {
                     Scheduler.runTask(true, () -> {
                         callViolationEvent(player, lacPlayer, null);
                     });
-                }, 1);
-            }, 1);
-        }, 1);
+                });
+            });
+        });
     }
 
     @EventHandler(priority = EventPriority.LOW)

--- a/src/main/java/me/vekster/lightanticheat/check/checks/combat/criticals/CriticalsB.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/combat/criticals/CriticalsB.java
@@ -125,17 +125,17 @@ public class CriticalsB extends CombatCheck implements Listener {
             return;
 
         Set<Integer> minHeights = ConcurrentHashMap.newKeySet();
-        Scheduler.runTaskLater(() -> {
+        Scheduler.runTaskLater(player, () -> {
             if (!player.isOnline() || LACPlayer.getLacPlayer(player) == null)
                 return;
             minHeights.add(getMinDownHeight(getDownBlocks(player, 0.1), true));
 
-            Scheduler.runTaskLater(() -> {
+            Scheduler.runTaskLater(player, () -> {
                 if (!player.isOnline() || LACPlayer.getLacPlayer(player) == null)
                     return;
                 minHeights.add(getMinDownHeight(getDownBlocks(player, 0.1), true));
 
-                Scheduler.runTaskLater(() -> {
+                Scheduler.runTaskLater(player, () -> {
                     if (!player.isOnline() || LACPlayer.getLacPlayer(player) == null)
                         return;
                     minHeights.add(getMinDownHeight(getDownBlocks(player, 0.1), true));

--- a/src/main/java/me/vekster/lightanticheat/check/checks/combat/criticals/CriticalsB.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/combat/criticals/CriticalsB.java
@@ -37,6 +37,8 @@ public class CriticalsB extends CombatCheck implements Listener {
 
     @EventHandler
     public void onAsyncHit(LACAsyncPlayerAttackEvent event) {
+        if (event.hasDamageCause() && !event.isEntityAttackCause())
+            return;
         LACPlayer lacPlayer = event.getLacPlayer();
         PlayerCache cache = lacPlayer.cache;
         Player player = event.getPlayer();

--- a/src/main/java/me/vekster/lightanticheat/check/checks/combat/killaura/KillAuraA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/combat/killaura/KillAuraA.java
@@ -26,6 +26,8 @@ public class KillAuraA extends CombatCheck implements Listener {
 
     @EventHandler
     public void onAsyncHit(LACAsyncPlayerAttackEvent event) {
+        if (event.hasDamageCause() && !event.isEntityAttackCause())
+            return;
         LACPlayer lacPlayer = event.getLacPlayer();
         PlayerCache cache = lacPlayer.cache;
         Player player = event.getPlayer();

--- a/src/main/java/me/vekster/lightanticheat/check/checks/combat/killaura/KillAuraB.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/combat/killaura/KillAuraB.java
@@ -31,6 +31,8 @@ public class KillAuraB extends CombatCheck implements Listener {
 
     @EventHandler
     public void onAsyncHit(LACAsyncPlayerAttackEvent event) {
+        if (event.hasDamageCause() && !event.isEntityAttackCause())
+            return;
         LACPlayer lacPlayer = event.getLacPlayer();
         Player player = event.getPlayer();
         Location eyeLocation = player.getEyeLocation().clone();

--- a/src/main/java/me/vekster/lightanticheat/check/checks/combat/killaura/KillAuraC.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/combat/killaura/KillAuraC.java
@@ -29,6 +29,8 @@ public class KillAuraC extends CombatCheck implements Listener {
 
     @EventHandler
     public void onAsyncHit(LACAsyncPlayerAttackEvent event) {
+        if (event.hasDamageCause() && !event.isEntityAttackCause())
+            return;
         LACPlayer lacPlayer = event.getLacPlayer();
         Player player = event.getPlayer();
 

--- a/src/main/java/me/vekster/lightanticheat/check/checks/combat/killaura/KillAuraD.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/combat/killaura/KillAuraD.java
@@ -26,6 +26,8 @@ public class KillAuraD extends CombatCheck implements Listener {
 
     @EventHandler
     public void multiAuraAsync(LACAsyncPlayerAttackEvent event) {
+        if (event.hasDamageCause() && !event.isEntityAttackCause())
+            return;
         LACPlayer lacPlayer = event.getLacPlayer();
         Buffer buffer = getBuffer(event.getPlayer(), true);
         long currentTime = System.currentTimeMillis();
@@ -78,6 +80,8 @@ public class KillAuraD extends CombatCheck implements Listener {
 
     @EventHandler
     public void shieldAsync(LACAsyncPlayerAttackEvent event) {
+        if (event.hasDamageCause() && !event.isEntityAttackCause())
+            return;
         Player player = event.getPlayer();
         if (!player.isBlocking() && !player.isSleeping() && !player.isDead())
             return;

--- a/src/main/java/me/vekster/lightanticheat/check/checks/combat/velocity/VelocityA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/combat/velocity/VelocityA.java
@@ -183,6 +183,20 @@ public class VelocityA extends CombatCheck implements Listener {
         }, 1);
     }
 
+    private static boolean hasRecent121CombatImpulse(PlayerCache cache, long time) {
+        int chargeReceiveWindow = 1000;
+        int burstWindow = 1750;
+        int burstNotVanillaWindow = 4500;
+        if (VerIdentifier.isAtLeastMinecraft(1, 21, 11)) {
+            chargeReceiveWindow += 350;
+            burstWindow += 500;
+            burstNotVanillaWindow += 1000;
+        }
+        return time - cache.lastWindChargeReceive <= chargeReceiveWindow ||
+                time - cache.lastWindBurst <= burstWindow ||
+                time - cache.lastWindBurstNotVanilla <= burstNotVanillaWindow;
+    }
+
     private static boolean isConditionAllowed(Player player, LACPlayer lacPlayer, PlayerCache cache) {
         for (Block block : getWithinBlocks(player)) {
             if (!isActuallyPassable(block) || !isActuallyPassable(block.getRelative(BlockFace.UP)))
@@ -218,6 +232,8 @@ public class VelocityA extends CombatCheck implements Listener {
                 time - cache.lastSlimeBlock <= 2000 || time - cache.lastHoneyBlock <= 1000 ||
                 time - cache.lastFlight <= 750 ||
                 time - cache.lastGliding <= 2000 || time - cache.lastRiptiding <= 3500)
+            return false;
+        if (hasRecent121CombatImpulse(cache, time))
             return false;
         return true;
     }

--- a/src/main/java/me/vekster/lightanticheat/check/checks/interaction/blockbreak/BlockBreakA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/interaction/blockbreak/BlockBreakA.java
@@ -76,7 +76,7 @@ public class BlockBreakA extends InteractionCheck implements Listener {
 
             if (AureliumSkillsHook.isPrevented(player) ||
                     VeinMinerHook.isPrevented(player) ||
-                    McMMOHook.isPrevented(block.getType()))
+                    McMMOHook.isPrevented(player, block))
                 return;
 
             if (EnchantsSquaredHook.hasEnchantment(player, "Excavation", "Deforestation", "Harvesting"))

--- a/src/main/java/me/vekster/lightanticheat/check/checks/interaction/blockbreak/BlockBreakA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/interaction/blockbreak/BlockBreakA.java
@@ -133,8 +133,7 @@ public class BlockBreakA extends InteractionCheck implements Listener {
 
     private boolean executeRaytrace(Player player, String blockWorld, int blockX, int blockZ, Material blockType, Buffer buffer) {
         try {
-            return Scheduler.entityThread(player, true, false,
-                    () -> flagRaytrace(player, blockWorld, blockX, blockZ, blockType));
+            return flagRaytrace(player, blockWorld, blockX, blockZ, blockType);
         } catch (IllegalStateException exception) {
             resetBuffer(buffer);
             return false;

--- a/src/main/java/me/vekster/lightanticheat/check/checks/interaction/blockbreak/BlockBreakA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/interaction/blockbreak/BlockBreakA.java
@@ -38,13 +38,9 @@ public class BlockBreakA extends InteractionCheck implements Listener {
         Buffer buffer = getBuffer(event.getPlayer(), true);
         if (!flagSafe(event.getPlayer(), event.getLacPlayer(), event.getBlockWorld(), true)) {
             buffer.put("lastAsyncResult", false);
-            buffer.put("forceFlagAsync", false);
             return;
         }
-
-        boolean forceFlag = shouldForceFlagByAngle(event.getBlockX(), event.getBlockZ(), event.getEyeLocation());
         buffer.put("lastAsyncResult", true);
-        buffer.put("forceFlagAsync", forceFlag);
     }
 
     @EventHandler
@@ -60,7 +56,7 @@ public class BlockBreakA extends InteractionCheck implements Listener {
         if (!flagSafe(player, lacPlayer, block.getWorld().getName(), false))
             return;
 
-        boolean forceFlag = buffer.getBoolean("forceFlagAsync") || shouldForceFlagByAngle(block.getX(), block.getZ(), eyeLocation);
+        boolean forceFlag = shouldForceFlagByAngle(block.getX(), block.getZ(), eyeLocation);
         boolean raytraceFlag = !forceFlag && executeRaytrace(player, block.getWorld().getName(), block.getX(), block.getZ(), block.getType(), buffer);
         if (!(forceFlag || raytraceFlag))
             return;

--- a/src/main/java/me/vekster/lightanticheat/check/checks/interaction/blockbreak/BlockBreakA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/interaction/blockbreak/BlockBreakA.java
@@ -38,11 +38,13 @@ public class BlockBreakA extends InteractionCheck implements Listener {
         Buffer buffer = getBuffer(event.getPlayer(), true);
         if (!flagSafe(event.getPlayer(), event.getLacPlayer(), event.getBlockWorld(), true)) {
             buffer.put("lastAsyncResult", false);
+            buffer.put("forceFlagAsync", false);
             return;
         }
 
         boolean forceFlag = shouldForceFlagByAngle(event.getBlockX(), event.getBlockZ(), event.getEyeLocation());
-        buffer.put("lastAsyncResult", forceFlag);
+        buffer.put("lastAsyncResult", true);
+        buffer.put("forceFlagAsync", forceFlag);
     }
 
     @EventHandler
@@ -58,8 +60,8 @@ public class BlockBreakA extends InteractionCheck implements Listener {
         if (!flagSafe(player, lacPlayer, block.getWorld().getName(), false))
             return;
 
-        boolean forceFlag = shouldForceFlagByAngle(block.getX(), block.getZ(), eyeLocation);
-        boolean raytraceFlag = !forceFlag && executeRaytrace(player, block.getX(), block.getZ(), block.getType(), buffer);
+        boolean forceFlag = buffer.getBoolean("forceFlagAsync") || shouldForceFlagByAngle(block.getX(), block.getZ(), eyeLocation);
+        boolean raytraceFlag = !forceFlag && executeRaytrace(player, block.getWorld().getName(), block.getX(), block.getZ(), block.getType(), buffer);
         if (!(forceFlag || raytraceFlag))
             return;
 
@@ -101,44 +103,42 @@ public class BlockBreakA extends InteractionCheck implements Listener {
         return angle > 120 && eyeLocation.getPitch() < 60 && eyeLocation.getPitch() > -40;
     }
 
-    private boolean flagRaytrace(Player player, int blockX, int blockZ, Material blockType, Buffer buffer) {
-        try {
-            boolean flag = true;
-            Location blockLocation = new Location(player.getWorld(), blockX, 0.0D, blockZ);
-            Block targetBlock = player.getTargetBlockExact(10);
+    private boolean flagRaytrace(Player player, String blockWorld, int blockX, int blockZ, Material blockType) {
+        if (!player.getWorld().getName().equals(blockWorld))
+            return false;
+
+        boolean flag = true;
+        Location blockLocation = new Location(player.getWorld(), blockX, 0.0D, blockZ);
+        Block targetBlock = player.getTargetBlockExact(10);
+        if (targetBlock != null)
+            if (distanceHorizontal(blockLocation, targetBlock.getLocation()) <= 3.5)
+                flag = false;
+
+        if (flag) {
+            Set<Material> transparent = new HashSet<>();
+            transparent.add(Material.AIR);
+            transparent.add(Material.WATER);
+            transparent.add(Material.LAVA);
+            transparent.add(blockType);
             if (targetBlock != null)
-                if (distanceHorizontal(blockLocation, targetBlock.getLocation()) <= 3.5)
+                transparent.add(targetBlock.getType());
+
+            List<Block> lineOfSight = player.getLineOfSight(transparent, 10);
+            for (Block block1 : lineOfSight) {
+                if (distanceHorizontal(blockLocation, block1.getLocation()) <= 3.0) {
                     flag = false;
-
-            if (flag) {
-                Set<Material> transparent = new HashSet<>();
-                transparent.add(Material.AIR);
-                transparent.add(Material.WATER);
-                transparent.add(Material.LAVA);
-                transparent.add(blockType);
-                if (targetBlock != null)
-                    transparent.add(targetBlock.getType());
-
-                List<Block> lineOfSight = player.getLineOfSight(transparent, 10);
-                for (Block block1 : lineOfSight) {
-                    if (distanceHorizontal(blockLocation, block1.getLocation()) <= 3.0) {
-                        flag = false;
-                        break;
-                    }
+                    break;
                 }
             }
-
-            return flag;
-        } catch (IllegalStateException exception) {
-            resetBuffer(buffer);
-            return false;
         }
+
+        return flag;
     }
 
-    private boolean executeRaytrace(Player player, int blockX, int blockZ, Material blockType, Buffer buffer) {
+    private boolean executeRaytrace(Player player, String blockWorld, int blockX, int blockZ, Material blockType, Buffer buffer) {
         try {
             return Scheduler.entityThread(player, true, false,
-                    () -> flagRaytrace(player, blockX, blockZ, blockType, buffer));
+                    () -> flagRaytrace(player, blockWorld, blockX, blockZ, blockType));
         } catch (IllegalStateException exception) {
             resetBuffer(buffer);
             return false;

--- a/src/main/java/me/vekster/lightanticheat/check/checks/interaction/blockbreak/BlockBreakB.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/interaction/blockbreak/BlockBreakB.java
@@ -76,7 +76,7 @@ public class BlockBreakB extends InteractionCheck implements Listener {
         Scheduler.runTask(true, () -> {
             if (AureliumSkillsHook.isPrevented(player) ||
                     VeinMinerHook.isPrevented(player) ||
-                    McMMOHook.isPrevented(block.getType()))
+                    McMMOHook.isPrevented(player, block))
                 return;
 
             if (EnchantsSquaredHook.hasEnchantment(player, "Excavation", "Deforestation", "Harvesting"))

--- a/src/main/java/me/vekster/lightanticheat/check/checks/interaction/blockplace/BlockPlaceA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/interaction/blockplace/BlockPlaceA.java
@@ -36,8 +36,7 @@ public class BlockPlaceA extends InteractionCheck implements Listener {
     @EventHandler
     public void onAsyncBlockBreak(LACAsyncPlayerPlaceBlockEvent event) {
         Buffer buffer = getBuffer(event.getPlayer(), true);
-        buffer.put("lastAsyncResult", flag(event.getPlayer(), event.getLacPlayer(),
-                event.getBlock(), event.getEyeLocation(), true));
+        buffer.put("lastAsyncResult", flagSafe(event.getPlayer(), event.getLacPlayer(), event.getBlock(), true));
     }
 
     @EventHandler
@@ -45,8 +44,17 @@ public class BlockPlaceA extends InteractionCheck implements Listener {
         Buffer buffer = getBuffer(event.getPlayer(), true);
         if (!buffer.getBoolean("lastAsyncResult"))
             return;
-        if (!flag(event.getPlayer(), event.getLacPlayer(),
-                event.getBlock(), event.getPlayer().getEyeLocation(), false))
+        Player player = event.getPlayer();
+        LACPlayer lacPlayer = event.getLacPlayer();
+        Block block = event.getBlock();
+        Location eyeLocation = player.getEyeLocation();
+
+        if (!flagSafe(player, lacPlayer, block, false))
+            return;
+
+        boolean forceFlag = shouldForceFlagByAngle(block, eyeLocation);
+        boolean raytraceFlag = executeRaytrace(player, block, buffer);
+        if (!(forceFlag || raytraceFlag))
             return;
 
         long currentTime = System.currentTimeMillis();
@@ -57,10 +65,6 @@ public class BlockPlaceA extends InteractionCheck implements Listener {
         buffer.put("flags", buffer.getInt("flags") + 1);
         if (buffer.getInt("flags") <= 1)
             return;
-
-        Player player = event.getPlayer();
-        LACPlayer lacPlayer = event.getLacPlayer();
-        Block block = event.getBlock();
 
         Scheduler.runTaskLater(player, () -> {
             if (getYawChange(player.getEyeLocation(), lacPlayer) > 35.0)
@@ -78,40 +82,67 @@ public class BlockPlaceA extends InteractionCheck implements Listener {
         }, 1);
     }
 
-    private boolean flag(Player player, LACPlayer lacPlayer, Block block, Location eyeLocation, boolean async) {
+    private boolean flagSafe(Player player, LACPlayer lacPlayer, Block block, boolean async) {
         if (!isCheckAllowed(player, lacPlayer, async))
             return false;
+        return player.getWorld() == block.getWorld();
+    }
 
-        boolean flag = true;
+    private boolean shouldForceFlagByAngle(Block block, Location eyeLocation) {
         Location blockLocation = block.getLocation();
-        Block targetBlock = lacPlayer.getTargetBlockExact(10);
-        if (targetBlock != null)
-            if (distanceHorizontal(blockLocation, targetBlock.getLocation()) <= 3.0)
-                flag = false;
-
-        if (flag) {
-            Set<Material> transparent = new HashSet<>();
-            transparent.add(Material.AIR);
-            transparent.add(Material.WATER);
-            transparent.add(Material.LAVA);
-            transparent.add(block.getType());
-            if (targetBlock != null)
-                transparent.add(targetBlock.getType());
-
-            List<Block> lineOfSight = player.getLineOfSight(transparent, 10);
-            for (Block block1 : lineOfSight) {
-                if (distanceHorizontal(blockLocation, block1.getLocation()) <= 2.5) {
-                    flag = false;
-                    break;
-                }
-            }
-        }
-
         Vector vector = blockLocation.toVector().setY(0.0D).subtract(eyeLocation.toVector().setY(0.0D));
         float angle = eyeLocation.getDirection().setY(0.0D).angle(vector) * 57.2958F;
-        if (angle > 110 && eyeLocation.getPitch() < 60 && eyeLocation.getPitch() > -40)
-            flag = true;
-        return flag;
+        return angle > 110 && eyeLocation.getPitch() < 60 && eyeLocation.getPitch() > -40;
+    }
+
+    private boolean flagRaytrace(Player player, Block block, Buffer buffer) {
+        try {
+            boolean flag = true;
+            Location blockLocation = block.getLocation();
+            Block targetBlock = player.getTargetBlockExact(10);
+            if (targetBlock != null)
+                if (distanceHorizontal(blockLocation, targetBlock.getLocation()) <= 3.0)
+                    flag = false;
+
+            if (flag) {
+                Set<Material> transparent = new HashSet<>();
+                transparent.add(Material.AIR);
+                transparent.add(Material.WATER);
+                transparent.add(Material.LAVA);
+                transparent.add(block.getType());
+                if (targetBlock != null)
+                    transparent.add(targetBlock.getType());
+
+                List<Block> lineOfSight = player.getLineOfSight(transparent, 10);
+                for (Block block1 : lineOfSight) {
+                    if (distanceHorizontal(blockLocation, block1.getLocation()) <= 2.5) {
+                        flag = false;
+                        break;
+                    }
+                }
+            }
+
+            return flag;
+        } catch (IllegalStateException exception) {
+            resetBuffer(buffer);
+            return false;
+        }
+    }
+
+    private boolean executeRaytrace(Player player, Block block, Buffer buffer) {
+        try {
+            return Scheduler.entityThread(player, true, false,
+                    () -> flagRaytrace(player, block, buffer));
+        } catch (IllegalStateException exception) {
+            resetBuffer(buffer);
+            return false;
+        }
+    }
+
+    private void resetBuffer(Buffer buffer) {
+        buffer.put("lastAsyncResult", false);
+        buffer.put("flags", 0);
+        buffer.put("lastFlag", 0L);
     }
 
     private static double getYawChange(Location eyeLocation, LACPlayer lacPlayer) {

--- a/src/main/java/me/vekster/lightanticheat/check/checks/interaction/blockplace/BlockPlaceA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/interaction/blockplace/BlockPlaceA.java
@@ -38,13 +38,9 @@ public class BlockPlaceA extends InteractionCheck implements Listener {
         Buffer buffer = getBuffer(event.getPlayer(), true);
         if (!flagSafe(event.getPlayer(), event.getLacPlayer(), event.getBlockWorld(), true)) {
             buffer.put("lastAsyncResult", false);
-            buffer.put("forceFlagAsync", false);
             return;
         }
-
-        boolean forceFlag = shouldForceFlagByAngle(event.getBlockX(), event.getBlockZ(), event.getEyeLocation());
         buffer.put("lastAsyncResult", true);
-        buffer.put("forceFlagAsync", forceFlag);
     }
 
     @EventHandler
@@ -60,7 +56,7 @@ public class BlockPlaceA extends InteractionCheck implements Listener {
         if (!flagSafe(player, lacPlayer, block.getWorld().getName(), false))
             return;
 
-        boolean forceFlag = buffer.getBoolean("forceFlagAsync") || shouldForceFlagByAngle(block.getX(), block.getZ(), eyeLocation);
+        boolean forceFlag = shouldForceFlagByAngle(block.getX(), block.getZ(), eyeLocation);
         boolean raytraceFlag = !forceFlag && executeRaytrace(player, block.getWorld().getName(), block.getX(), block.getZ(), block.getType(), buffer);
         if (!(forceFlag || raytraceFlag))
             return;

--- a/src/main/java/me/vekster/lightanticheat/check/checks/interaction/blockplace/BlockPlaceA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/interaction/blockplace/BlockPlaceA.java
@@ -36,7 +36,13 @@ public class BlockPlaceA extends InteractionCheck implements Listener {
     @EventHandler
     public void onAsyncBlockBreak(LACAsyncPlayerPlaceBlockEvent event) {
         Buffer buffer = getBuffer(event.getPlayer(), true);
-        buffer.put("lastAsyncResult", flagSafe(event.getPlayer(), event.getLacPlayer(), event.getBlock(), true));
+        if (!flagSafe(event.getPlayer(), event.getLacPlayer(), event.getBlockWorld(), true)) {
+            buffer.put("lastAsyncResult", false);
+            return;
+        }
+
+        boolean forceFlag = shouldForceFlagByAngle(event.getBlockX(), event.getBlockZ(), event.getEyeLocation());
+        buffer.put("lastAsyncResult", forceFlag);
     }
 
     @EventHandler
@@ -49,11 +55,11 @@ public class BlockPlaceA extends InteractionCheck implements Listener {
         Block block = event.getBlock();
         Location eyeLocation = player.getEyeLocation();
 
-        if (!flagSafe(player, lacPlayer, block, false))
+        if (!flagSafe(player, lacPlayer, block.getWorld().getName(), false))
             return;
 
-        boolean forceFlag = shouldForceFlagByAngle(block, eyeLocation);
-        boolean raytraceFlag = executeRaytrace(player, block, buffer);
+        boolean forceFlag = shouldForceFlagByAngle(block.getX(), block.getZ(), eyeLocation);
+        boolean raytraceFlag = !forceFlag && executeRaytrace(player, block.getX(), block.getZ(), block.getType(), buffer);
         if (!(forceFlag || raytraceFlag))
             return;
 
@@ -82,23 +88,23 @@ public class BlockPlaceA extends InteractionCheck implements Listener {
         }, 1);
     }
 
-    private boolean flagSafe(Player player, LACPlayer lacPlayer, Block block, boolean async) {
+    private boolean flagSafe(Player player, LACPlayer lacPlayer, String blockWorld, boolean async) {
         if (!isCheckAllowed(player, lacPlayer, async))
             return false;
-        return player.getWorld() == block.getWorld();
+        return player.getWorld().getName().equals(blockWorld);
     }
 
-    private boolean shouldForceFlagByAngle(Block block, Location eyeLocation) {
-        Location blockLocation = block.getLocation();
-        Vector vector = blockLocation.toVector().setY(0.0D).subtract(eyeLocation.toVector().setY(0.0D));
+    private boolean shouldForceFlagByAngle(int blockX, int blockZ, Location eyeLocation) {
+        Vector vector = new Vector(blockX + 0.5D, 0.0D, blockZ + 0.5D)
+                .subtract(eyeLocation.toVector().setY(0.0D));
         float angle = eyeLocation.getDirection().setY(0.0D).angle(vector) * 57.2958F;
         return angle > 110 && eyeLocation.getPitch() < 60 && eyeLocation.getPitch() > -40;
     }
 
-    private boolean flagRaytrace(Player player, Block block, Buffer buffer) {
+    private boolean flagRaytrace(Player player, int blockX, int blockZ, Material blockType, Buffer buffer) {
         try {
             boolean flag = true;
-            Location blockLocation = block.getLocation();
+            Location blockLocation = new Location(player.getWorld(), blockX, 0.0D, blockZ);
             Block targetBlock = player.getTargetBlockExact(10);
             if (targetBlock != null)
                 if (distanceHorizontal(blockLocation, targetBlock.getLocation()) <= 3.0)
@@ -109,7 +115,7 @@ public class BlockPlaceA extends InteractionCheck implements Listener {
                 transparent.add(Material.AIR);
                 transparent.add(Material.WATER);
                 transparent.add(Material.LAVA);
-                transparent.add(block.getType());
+                transparent.add(blockType);
                 if (targetBlock != null)
                     transparent.add(targetBlock.getType());
 
@@ -129,10 +135,10 @@ public class BlockPlaceA extends InteractionCheck implements Listener {
         }
     }
 
-    private boolean executeRaytrace(Player player, Block block, Buffer buffer) {
+    private boolean executeRaytrace(Player player, int blockX, int blockZ, Material blockType, Buffer buffer) {
         try {
             return Scheduler.entityThread(player, true, false,
-                    () -> flagRaytrace(player, block, buffer));
+                    () -> flagRaytrace(player, blockX, blockZ, blockType, buffer));
         } catch (IllegalStateException exception) {
             resetBuffer(buffer);
             return false;

--- a/src/main/java/me/vekster/lightanticheat/check/checks/interaction/blockplace/BlockPlaceA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/interaction/blockplace/BlockPlaceA.java
@@ -133,8 +133,7 @@ public class BlockPlaceA extends InteractionCheck implements Listener {
 
     private boolean executeRaytrace(Player player, String blockWorld, int blockX, int blockZ, Material blockType, Buffer buffer) {
         try {
-            return Scheduler.entityThread(player, true, false,
-                    () -> flagRaytrace(player, blockWorld, blockX, blockZ, blockType));
+            return flagRaytrace(player, blockWorld, blockX, blockZ, blockType);
         } catch (IllegalStateException exception) {
             resetBuffer(buffer);
             return false;

--- a/src/main/java/me/vekster/lightanticheat/check/checks/interaction/fastbreak/FastBreakA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/interaction/fastbreak/FastBreakA.java
@@ -4,20 +4,18 @@ import me.vekster.lightanticheat.check.CheckName;
 import me.vekster.lightanticheat.check.buffer.Buffer;
 import me.vekster.lightanticheat.check.checks.interaction.InteractionCheck;
 import me.vekster.lightanticheat.event.playerbreakblock.LACPlayerBreakBlockEvent;
-import me.vekster.lightanticheat.event.playermove.LACAsyncPlayerMoveEvent;
 import me.vekster.lightanticheat.player.LACPlayer;
 import me.vekster.lightanticheat.util.hook.plugin.simplehook.AureliumSkillsHook;
 import me.vekster.lightanticheat.util.hook.plugin.simplehook.EnchantsSquaredHook;
 import me.vekster.lightanticheat.util.hook.plugin.simplehook.McMMOHook;
 import me.vekster.lightanticheat.util.hook.plugin.simplehook.VeinMinerHook;
-import me.vekster.lightanticheat.util.scheduler.Scheduler;
+import me.vekster.lightanticheat.version.VerPlayer;
 import me.vekster.lightanticheat.version.VerUtil;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
@@ -31,35 +29,24 @@ import java.util.Map;
  * Mining with a pickaxe using Timer or FastBreak hack
  */
 public class FastBreakA extends InteractionCheck implements Listener {
+    private static final Map<Material, Double> BLOCK_HARDNESS = new HashMap<>();
+    private static final Map<Material, Double> TOOL_SPEED = new HashMap<>();
+    private static final Map<Material, Integer> TOOL_TIERS = new HashMap<>();
 
-    static class Duration {
-        public Duration(int stone, int deepslate) {
-            DURATIONS.put(Material.STONE, stone);
-            DURATIONS.put(VerUtil.material.get("DEEPSLATE"), deepslate);
-        }
-
-        private final Map<Material, Integer> DURATIONS = new HashMap<>();
-
-        public int getDuration(Material material) {
-            return DURATIONS.getOrDefault(material, 0);
-        }
-    }
-
-    private static final Map<Material, Duration> DURATIONS = new HashMap<>();
-    private static final Map<Material, Duration> ENCHANTED_DURATIONS = new HashMap<>();
+    private static final long TICK_ROUNDING_TOLERANCE_MS = 75L;
+    private static final long LATENCY_SPIKE_TOLERANCE_MS = 150L;
+    private static final double BASE_BREAK_THRESHOLD_RATIO = 1.45;
 
     static {
-        DURATIONS.put(VerUtil.material.get("WOODEN_PICKAXE"), new Duration(1150, 2250));
-        DURATIONS.put(Material.STONE_PICKAXE, new Duration(600, 1150));
-        DURATIONS.put(Material.IRON_PICKAXE, new Duration(400, 750));
-        DURATIONS.put(Material.DIAMOND_PICKAXE, new Duration(300, 600));
-        DURATIONS.put(VerUtil.material.get("NETHERITE_PICKAXE"), new Duration(250, 500));
+        BLOCK_HARDNESS.put(Material.STONE, 1.5D);
+        BLOCK_HARDNESS.put(VerUtil.material.get("DEEPSLATE"), 3.0D);
 
-        ENCHANTED_DURATIONS.put(VerUtil.material.get("WOODEN_PICKAXE"), new Duration(100, 200));
-        ENCHANTED_DURATIONS.put(Material.STONE_PICKAXE, new Duration(100, 150));
-        ENCHANTED_DURATIONS.put(Material.IRON_PICKAXE, new Duration(100, 150));
-        ENCHANTED_DURATIONS.put(Material.DIAMOND_PICKAXE, new Duration(100, 150));
-        ENCHANTED_DURATIONS.put(VerUtil.material.get("NETHERITE_PICKAXE"), new Duration(100, 150));
+        registerPickaxe(VerUtil.material.get("WOODEN_PICKAXE"), 2.0D, 1);
+        registerPickaxe(Material.STONE_PICKAXE, 4.0D, 2);
+        registerPickaxe(Material.IRON_PICKAXE, 6.0D, 3);
+        registerPickaxe(Material.DIAMOND_PICKAXE, 8.0D, 4);
+        registerPickaxe(VerUtil.material.get("NETHERITE_PICKAXE"), 9.0D, 4);
+        registerPickaxe(VerUtil.material.get("GOLDEN_PICKAXE"), 12.0D, 1);
     }
 
     public FastBreakA() {
@@ -87,14 +74,13 @@ public class FastBreakA extends InteractionCheck implements Listener {
         int efficiencyLevel = tool.getEnchantmentLevel(VerUtil.enchantment.get("EFFICIENCY"));
         if (efficiencyLevel > 5)
             return;
-        boolean enchantedTool = efficiencyLevel != 0;
 
-        if (block.getType() != Material.STONE && block.getType() != VerUtil.material.get("DEEPSLATE")) {
+        if (!BLOCK_HARDNESS.containsKey(block.getType())) {
             if (buffer.getInt("flags") > 0)
                 buffer.put("flags", buffer.getInt("flags") - 1);
             return;
         }
-        if (!DURATIONS.containsKey(tool.getType()) || !ENCHANTED_DURATIONS.containsKey(tool.getType())) {
+        if (!TOOL_SPEED.containsKey(tool.getType())) {
             if (buffer.getInt("flags") > 0)
                 buffer.put("flags", buffer.getInt("flags") - 1);
             return;
@@ -120,26 +106,26 @@ public class FastBreakA extends InteractionCheck implements Listener {
             return;
         }
 
-        if (!buffer.isExists("enchantedTool") || buffer.getBoolean("enchantedTool") != enchantedTool) {
-            buffer.put("enchantedTool", enchantedTool);
+        if (!buffer.isExists("efficiencyLevel") || buffer.getInt("efficiencyLevel") != efficiencyLevel) {
+            buffer.put("efficiencyLevel", efficiencyLevel);
             if (buffer.getInt("flags") > 0)
                 buffer.put("flags", buffer.getInt("flags") - 1);
             return;
         }
 
-        long currentTime = System.currentTimeMillis();
-        if (currentTime - buffer.getLong("effectTime") <= 10 * 1000) {
-            buffer.put("flags", 0);
+        int environmentSignature = getEnvironmentSignature(player, tool);
+        if (!buffer.isExists("environmentSignature") || buffer.getInt("environmentSignature") != environmentSignature) {
+            buffer.put("environmentSignature", environmentSignature);
+            if (buffer.getInt("flags") > 0)
+                buffer.put("flags", buffer.getInt("flags") - 1);
             return;
         }
 
         long interval = System.currentTimeMillis() - buffer.getLong("lastInteraction");
 
-        long maxDuration = !enchantedTool ?
-                DURATIONS.get(tool.getType()).getDuration(block.getType()) :
-                ENCHANTED_DURATIONS.get(tool.getType()).getDuration(block.getType());
-
-        boolean flag = interval < maxDuration / 1.45;
+        long maxDuration = getExpectedMineDuration(player, block, tool, efficiencyLevel);
+        long tolerance = getIntervalTolerance(player);
+        boolean flag = interval + tolerance < maxDuration / BASE_BREAK_THRESHOLD_RATIO;
 
         if (flag) {
             if (buffer.getInt("flags") < 6)
@@ -174,6 +160,90 @@ public class FastBreakA extends InteractionCheck implements Listener {
         callViolationEvent(player, lacPlayer, event.getEvent());
     }
 
+    private static void registerPickaxe(Material tool, double speed, int tier) {
+        TOOL_SPEED.put(tool, speed);
+        TOOL_TIERS.put(tool, tier);
+    }
+
+    private long getExpectedMineDuration(Player player, Block block, ItemStack tool, int efficiencyLevel) {
+        double hardness = BLOCK_HARDNESS.getOrDefault(block.getType(), 1.5D);
+        double speedMultiplier = getToolSpeedMultiplier(player, block, tool, efficiencyLevel);
+        double damagePerTick = speedMultiplier / hardness / 30.0D;
+
+        int ticksToBreak = (int) Math.ceil(1.0D / Math.max(damagePerTick, 1.0E-4D));
+        return ticksToBreak * 50L;
+    }
+
+    private double getToolSpeedMultiplier(Player player, Block block, ItemStack tool, int efficiencyLevel) {
+        double speedMultiplier = TOOL_SPEED.getOrDefault(tool.getType(), 1.0D);
+        if (!canHarvest(block, tool))
+            speedMultiplier = 1.0D;
+
+        if (speedMultiplier > 1.0D && efficiencyLevel > 0)
+            speedMultiplier += efficiencyLevel * efficiencyLevel + 1.0D;
+
+        int hasteLevel = getEffectAmplifier(player, PotionEffectType.HASTE);
+        if (hasteLevel > 0)
+            speedMultiplier *= 1.0D + hasteLevel * 0.2D;
+
+        PotionEffectType fatigueType = VerUtil.potions.getOrDefault("MINING_FATIGUE", PotionEffectType.SLOW_DIGGING);
+        if (fatigueType != null) {
+            int fatigueLevel = getEffectAmplifier(player, fatigueType);
+            if (fatigueLevel > 0)
+                speedMultiplier *= getMiningFatigueMultiplier(fatigueLevel);
+        }
+
+        if (isUnderwater(player) && hasNoAquaAffinity(tool))
+            speedMultiplier /= 5.0D;
+
+        return Math.max(speedMultiplier, 0.0001D);
+    }
+
+    private boolean canHarvest(Block block, ItemStack tool) {
+        int requiredTier = block.getType() == VerUtil.material.get("DEEPSLATE") ? 1 : 1;
+        int toolTier = TOOL_TIERS.getOrDefault(tool.getType(), 0);
+        return toolTier >= requiredTier;
+    }
+
+    private boolean hasNoAquaAffinity(ItemStack tool) {
+        if (VerUtil.enchantment.get("AQUA_AFFINITY") == null)
+            return true;
+        return tool.getEnchantmentLevel(VerUtil.enchantment.get("AQUA_AFFINITY")) <= 0;
+    }
+
+    private boolean isUnderwater(Player player) {
+        Material eyeBlockType = player.getEyeLocation().getBlock().getType();
+        return eyeBlockType == Material.WATER;
+    }
+
+    private double getMiningFatigueMultiplier(int fatigueLevel) {
+        switch (fatigueLevel) {
+            case 1:
+                return 0.3D;
+            case 2:
+                return 0.09D;
+            case 3:
+                return 0.0027D;
+            default:
+                return 0.00081D;
+        }
+    }
+
+    private long getIntervalTolerance(Player player) {
+        long pingTolerance = Math.min(200L, Math.round(VerPlayer.getPing(player) * 0.35D));
+        return TICK_ROUNDING_TOLERANCE_MS + LATENCY_SPIKE_TOLERANCE_MS + pingTolerance;
+    }
+
+    private int getEnvironmentSignature(Player player, ItemStack tool) {
+        int hasteLevel = getEffectAmplifier(player, PotionEffectType.HASTE);
+        PotionEffectType fatigueType = VerUtil.potions.getOrDefault("MINING_FATIGUE", PotionEffectType.SLOW_DIGGING);
+        int fatigueLevel = fatigueType == null ? 0 : getEffectAmplifier(player, fatigueType);
+        int underwater = isUnderwater(player) ? 1 : 0;
+        int aquaAffinity = hasNoAquaAffinity(tool) ? 0 : 1;
+
+        return hasteLevel * 1000 + fatigueLevel * 100 + underwater * 10 + aquaAffinity;
+    }
+
     @EventHandler
     public void onInteraction(PlayerInteractEvent event) {
         if (isExternalNPC(event)) return;
@@ -184,34 +254,5 @@ public class FastBreakA extends InteractionCheck implements Listener {
         buffer.put("lastInteraction", System.currentTimeMillis());
     }
 
-    @EventHandler(priority = EventPriority.LOW)
-    public void beforeBlockBreak(LACPlayerBreakBlockEvent event) {
-        LACPlayer lacPlayer = event.getLacPlayer();
-        Player player = event.getPlayer();
-
-        if (!isCheckAllowed(player, lacPlayer))
-            return;
-
-        if (getEffectAmplifier(player, PotionEffectType.HASTE) > 0) {
-            Buffer buffer = getBuffer(player);
-            buffer.put("effectTime", System.currentTimeMillis());
-        }
-    }
-
-    @EventHandler(priority = EventPriority.LOW)
-    public void onMovement(LACAsyncPlayerMoveEvent event) {
-        LACPlayer lacPlayer = event.getLacPlayer();
-        Player player = event.getPlayer();
-
-        if (!isCheckAllowed(player, lacPlayer, true))
-            return;
-
-        if (getEffectAmplifier(lacPlayer.cache, PotionEffectType.HASTE) > 0) {
-            Scheduler.runTask(true, () -> {
-                Buffer buffer = getBuffer(player);
-                buffer.put("effectTime", System.currentTimeMillis());
-            });
-        }
-    }
 
 }

--- a/src/main/java/me/vekster/lightanticheat/check/checks/interaction/fastbreak/FastBreakA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/interaction/fastbreak/FastBreakA.java
@@ -192,7 +192,7 @@ public class FastBreakA extends InteractionCheck implements Listener {
         if (!isCheckAllowed(player, lacPlayer))
             return;
 
-        if (getEffectAmplifier(player, PotionEffectType.FAST_DIGGING) > 0) {
+        if (getEffectAmplifier(player, PotionEffectType.HASTE) > 0) {
             Buffer buffer = getBuffer(player);
             buffer.put("effectTime", System.currentTimeMillis());
         }
@@ -206,7 +206,7 @@ public class FastBreakA extends InteractionCheck implements Listener {
         if (!isCheckAllowed(player, lacPlayer, true))
             return;
 
-        if (getEffectAmplifier(lacPlayer.cache, PotionEffectType.FAST_DIGGING) > 0) {
+        if (getEffectAmplifier(lacPlayer.cache, PotionEffectType.HASTE) > 0) {
             Scheduler.runTask(true, () -> {
                 Buffer buffer = getBuffer(player);
                 buffer.put("effectTime", System.currentTimeMillis());

--- a/src/main/java/me/vekster/lightanticheat/check/checks/interaction/fastbreak/FastBreakA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/interaction/fastbreak/FastBreakA.java
@@ -78,7 +78,7 @@ public class FastBreakA extends InteractionCheck implements Listener {
         Block block = event.getBlock();
         if (AureliumSkillsHook.isPrevented(player) ||
                 VeinMinerHook.isPrevented(player) ||
-                McMMOHook.isPrevented(block.getType()))
+                McMMOHook.isPrevented(player, block))
             return;
 
         Buffer buffer = getBuffer(player);

--- a/src/main/java/me/vekster/lightanticheat/check/checks/interaction/fastbreak/FastBreakA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/interaction/fastbreak/FastBreakA.java
@@ -40,17 +40,21 @@ public class FastBreakA extends InteractionCheck implements Listener {
 
     static {
         BLOCK_HARDNESS.put(Material.STONE, 1.5D);
-        BLOCK_HARDNESS.put(VerUtil.material.get("DEEPSLATE"), 3.0D);
-
         BLOCK_REQUIRED_TOOL_TIER.put(Material.STONE, 1);
-        BLOCK_REQUIRED_TOOL_TIER.put(VerUtil.material.get("DEEPSLATE"), 1);
 
-        registerPickaxe(VerUtil.material.get("WOODEN_PICKAXE"), 2.0D, 1);
+        Material deepslate = VerUtil.material.get("DEEPSLATE");
+        if (deepslate != null) {
+            BLOCK_HARDNESS.put(deepslate, 3.0D);
+            BLOCK_REQUIRED_TOOL_TIER.put(deepslate, 1);
+        }
+
+        registerPickaxeIfPresent("WOODEN_PICKAXE", 2.0D, 1);
         registerPickaxe(Material.STONE_PICKAXE, 4.0D, 2);
         registerPickaxe(Material.IRON_PICKAXE, 6.0D, 3);
         registerPickaxe(Material.DIAMOND_PICKAXE, 8.0D, 4);
-        registerPickaxe(VerUtil.material.get("NETHERITE_PICKAXE"), 9.0D, 4);
-        registerPickaxe(VerUtil.material.get("GOLDEN_PICKAXE"), 12.0D, 1);
+        registerPickaxeIfPresent("NETHERITE_PICKAXE", 9.0D, 4);
+        registerPickaxeIfPresent("GOLDEN_PICKAXE", 12.0D, 1);
+        registerPickaxeIfPresent("GOLD_PICKAXE", 12.0D, 1);
     }
 
     public FastBreakA() {
@@ -166,6 +170,12 @@ public class FastBreakA extends InteractionCheck implements Listener {
     private static void registerPickaxe(Material tool, double speed, int tier) {
         TOOL_SPEED.put(tool, speed);
         TOOL_TIERS.put(tool, tier);
+    }
+
+    private static void registerPickaxeIfPresent(String materialKey, double speed, int tier) {
+        Material material = VerUtil.material.get(materialKey);
+        if (material != null)
+            registerPickaxe(material, speed, tier);
     }
 
     private long getExpectedMineDuration(Player player, Block block, ItemStack tool, int efficiencyLevel) {

--- a/src/main/java/me/vekster/lightanticheat/check/checks/interaction/fastbreak/FastBreakA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/interaction/fastbreak/FastBreakA.java
@@ -198,7 +198,7 @@ public class FastBreakA extends InteractionCheck implements Listener {
         if (hasteLevel > 0)
             speedMultiplier *= 1.0D + hasteLevel * 0.2D;
 
-        PotionEffectType fatigueType = VerUtil.potions.getOrDefault("MINING_FATIGUE", PotionEffectType.SLOW_DIGGING);
+        PotionEffectType fatigueType = VerUtil.potions.getOrDefault("MINING_FATIGUE", PotionEffectType.MINING_FATIGUE);
         if (fatigueType != null) {
             int fatigueLevel = getEffectAmplifier(player, fatigueType);
             if (fatigueLevel > 0)
@@ -255,7 +255,7 @@ public class FastBreakA extends InteractionCheck implements Listener {
 
     private int getEnvironmentSignature(Player player) {
         int hasteLevel = getEffectAmplifier(player, PotionEffectType.HASTE);
-        PotionEffectType fatigueType = VerUtil.potions.getOrDefault("MINING_FATIGUE", PotionEffectType.SLOW_DIGGING);
+        PotionEffectType fatigueType = VerUtil.potions.getOrDefault("MINING_FATIGUE", PotionEffectType.MINING_FATIGUE);
         int fatigueLevel = fatigueType == null ? 0 : getEffectAmplifier(player, fatigueType);
         int underwater = isUnderwater(player) ? 1 : 0;
         int aquaAffinity = hasAquaAffinity(player) ? 1 : 0;

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/MovementCheck.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/MovementCheck.java
@@ -58,22 +58,32 @@ public abstract class MovementCheck extends Check {
 
 
     protected boolean hasRecent121MobilityBoost(PlayerCache cache, long time, boolean strict) {
-        int windChargeWindow = strict ? 1000 : 500;
-        int windChargeReceiveWindow = strict ? 750 : 500;
-        int windBurstWindow = strict ? 1500 : 500;
-        int windBurstCustomWindow = strict ? 4000 : 1000;
+        if (strict)
+            return hasRecent121MobilityBoost(cache, time, 1000, 500, 1500, 4000);
+        return hasRecent121MobilityBoost(cache, time, 500, 750, 500, 1000);
+    }
+
+    protected boolean hasRecent121MobilityBoost(PlayerCache cache, long time,
+                                                int windChargeWindow,
+                                                int windChargeReceiveWindow,
+                                                int windBurstWindow,
+                                                int windBurstCustomWindow) {
+        int adjustedWindChargeWindow = windChargeWindow;
+        int adjustedWindChargeReceiveWindow = windChargeReceiveWindow;
+        int adjustedWindBurstWindow = windBurstWindow;
+        int adjustedWindBurstCustomWindow = windBurstCustomWindow;
 
         if (VerIdentifier.isAtLeastMinecraft(1, 21, 11)) {
-            windChargeWindow += strict ? 350 : 250;
-            windChargeReceiveWindow += strict ? 350 : 250;
-            windBurstWindow += strict ? 500 : 250;
-            windBurstCustomWindow += strict ? 750 : 500;
+            adjustedWindChargeWindow += 250;
+            adjustedWindChargeReceiveWindow += 250;
+            adjustedWindBurstWindow += 250;
+            adjustedWindBurstCustomWindow += 500;
         }
 
-        return time - cache.lastWindCharge <= windChargeWindow ||
-                time - cache.lastWindChargeReceive <= windChargeReceiveWindow ||
-                time - cache.lastWindBurst <= windBurstWindow ||
-                time - cache.lastWindBurstNotVanilla <= windBurstCustomWindow;
+        return time - cache.lastWindCharge <= adjustedWindChargeWindow ||
+                time - cache.lastWindChargeReceive <= adjustedWindChargeReceiveWindow ||
+                time - cache.lastWindBurst <= adjustedWindBurstWindow ||
+                time - cache.lastWindBurstNotVanilla <= adjustedWindBurstCustomWindow;
     }
 
     public boolean isLagGlidingPossible(Player player, Buffer buffer, int requiredAccuracy) {

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/MovementCheck.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/MovementCheck.java
@@ -49,13 +49,20 @@ public abstract class MovementCheck extends Check {
     }
 
 
+    private ConnectionStability getConnectionStabilitySafe(Player player) {
+        try {
+            return ConnectionStabilityListener.getConnectionStability(player);
+        } catch (RuntimeException ignored) {
+            return ConnectionStability.HIGH;
+        }
+    }
 
 
     protected long getDynamicGraceWindow(LACPlayer lacPlayer, Player player, long baseWindow) {
         int ping = Math.max(lacPlayer.getPing(true), 0);
         long pingGrace = Math.max(0, ping - 120L);
 
-        ConnectionStability stability = ConnectionStabilityListener.getConnectionStability(player);
+        ConnectionStability stability = getConnectionStabilitySafe(player);
         long jitterGrace = 0;
         if (stability == ConnectionStability.MEDIUM)
             jitterGrace = 150;
@@ -69,7 +76,7 @@ public abstract class MovementCheck extends Check {
         int ping = Math.max(lacPlayer.getPing(true), 0);
         int pingBuffer = ping > 350 ? 3 : ping > 220 ? 2 : ping > 140 ? 1 : 0;
 
-        ConnectionStability stability = ConnectionStabilityListener.getConnectionStability(player);
+        ConnectionStability stability = getConnectionStabilitySafe(player);
         int jitterBuffer = stability == ConnectionStability.LOW ? 2 : stability == ConnectionStability.MEDIUM ? 1 : 0;
         return baseBuffer + pingBuffer + jitterBuffer;
     }

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/MovementCheck.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/MovementCheck.java
@@ -59,7 +59,7 @@ public abstract class MovementCheck extends Check {
     }
 
 
-    protected long getDynamicGraceWindow(LACPlayer lacPlayer, Player player, long baseWindow) {
+    protected long getDynamicGraceWindow(LACPlayer lacPlayer, long baseWindow) {
         int ping = Math.max(lacPlayer.getPing(true), 0);
         long pingGrace = Math.max(0, ping - 120L);
 
@@ -73,7 +73,7 @@ public abstract class MovementCheck extends Check {
         return baseWindow + Math.min(1200, pingGrace + jitterGrace);
     }
 
-    protected int getConnectionBufferRequirement(LACPlayer lacPlayer, Player player, int baseBuffer) {
+    protected int getConnectionBufferRequirement(LACPlayer lacPlayer, int baseBuffer) {
         int ping = Math.max(lacPlayer.getPing(true), 0);
         int pingBuffer = ping > 350 ? 3 : ping > 220 ? 2 : ping > 140 ? 1 : 0;
 

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/MovementCheck.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/MovementCheck.java
@@ -51,7 +51,7 @@ public abstract class MovementCheck extends Check {
 
     private ConnectionStability getConnectionStabilitySafe(LACPlayer lacPlayer) {
         try {
-            ConnectionStability stability = ConnectionStabilityListener.getConnectionStability(lacPlayer.uuid);
+            ConnectionStability stability = ConnectionStabilityListener.getConnectionStability(lacPlayer.getUuid());
             return stability != null ? stability : ConnectionStability.HIGH;
         } catch (RuntimeException | LinkageError ignored) {
             return ConnectionStability.HIGH;

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/MovementCheck.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/MovementCheck.java
@@ -51,7 +51,8 @@ public abstract class MovementCheck extends Check {
 
     private ConnectionStability getConnectionStabilitySafe(Player player) {
         try {
-            return ConnectionStabilityListener.getConnectionStability(player);
+            ConnectionStability stability = ConnectionStabilityListener.getConnectionStability(player);
+            return stability != null ? stability : ConnectionStability.HIGH;
         } catch (RuntimeException ignored) {
             return ConnectionStability.HIGH;
         }
@@ -82,11 +83,12 @@ public abstract class MovementCheck extends Check {
     }
 
     protected boolean hasInstabilityCooldown(PlayerCache cache, long time, long cooldownWindow) {
+        long climbingTransitionWindow = Math.min(cooldownWindow, 250);
         return time - cache.lastWindCharge <= cooldownWindow ||
                 time - cache.lastWindChargeReceive <= cooldownWindow ||
                 time - cache.lastWindBurst <= cooldownWindow ||
                 time - cache.lastWindBurstNotVanilla <= cooldownWindow + 400 ||
-                time - cache.lastClimbingTransition <= cooldownWindow ||
+                time - cache.lastClimbingTransition <= climbingTransitionWindow ||
                 time - cache.lastTeleport <= cooldownWindow;
     }
 

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/MovementCheck.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/MovementCheck.java
@@ -11,6 +11,7 @@ import me.vekster.lightanticheat.util.cooldown.CooldownUtil;
 import me.vekster.lightanticheat.util.hook.plugin.simplehook.EnchantsSquaredHook;
 import me.vekster.lightanticheat.version.VerPlayer;
 import me.vekster.lightanticheat.version.VerUtil;
+import me.vekster.lightanticheat.version.identifier.VerIdentifier;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
@@ -53,6 +54,26 @@ public abstract class MovementCheck extends Check {
         if (VerPlayer.getPing(player) > 500 && (currentTime - cache.lastGliding < 3000 || currentTime - cache.lastRiptiding < 4000))
             return true;
         return false;
+    }
+
+
+    protected boolean hasRecent121MobilityBoost(PlayerCache cache, long time, boolean strict) {
+        int windChargeWindow = strict ? 1000 : 500;
+        int windChargeReceiveWindow = strict ? 750 : 500;
+        int windBurstWindow = strict ? 1500 : 500;
+        int windBurstCustomWindow = strict ? 4000 : 1000;
+
+        if (VerIdentifier.isAtLeastMinecraft(1, 21, 11)) {
+            windChargeWindow += strict ? 350 : 250;
+            windChargeReceiveWindow += strict ? 350 : 250;
+            windBurstWindow += strict ? 500 : 250;
+            windBurstCustomWindow += strict ? 750 : 500;
+        }
+
+        return time - cache.lastWindCharge <= windChargeWindow ||
+                time - cache.lastWindChargeReceive <= windChargeReceiveWindow ||
+                time - cache.lastWindBurst <= windBurstWindow ||
+                time - cache.lastWindBurstNotVanilla <= windBurstCustomWindow;
     }
 
     public boolean isLagGlidingPossible(Player player, Buffer buffer, int requiredAccuracy) {

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/MovementCheck.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/MovementCheck.java
@@ -83,6 +83,33 @@ public abstract class MovementCheck extends Check {
         return baseBuffer + dynamicIncrease;
     }
 
+
+    protected boolean isHighPingPlayer(LACPlayer lacPlayer) {
+        return Math.max(lacPlayer.getPing(true), 0) >= 220;
+    }
+
+    protected long getPingAwareWindow(LACPlayer lacPlayer, long normalWindow, long highPingWindow) {
+        return isHighPingPlayer(lacPlayer) ? highPingWindow : normalWindow;
+    }
+
+    protected boolean hasRecentMobilityContext(PlayerCache cache, LACPlayer lacPlayer, long time,
+                                               long normalElytraWindow,
+                                               long highPingElytraWindow,
+                                               long normalRiptideWindow,
+                                               long highPingRiptideWindow,
+                                               long normalExplosionWindow,
+                                               long highPingExplosionWindow) {
+        long elytraWindow = getPingAwareWindow(lacPlayer, normalElytraWindow, highPingElytraWindow);
+        long riptideWindow = getPingAwareWindow(lacPlayer, normalRiptideWindow, highPingRiptideWindow);
+        long explosionWindow = getPingAwareWindow(lacPlayer, normalExplosionWindow, highPingExplosionWindow);
+
+        return time - cache.lastElytraEquip <= elytraWindow ||
+                time - cache.lastElytraUnequip <= elytraWindow ||
+                time - cache.lastRiptideDash <= riptideWindow ||
+                time - cache.lastEndCrystalImpact <= explosionWindow ||
+                time - cache.lastWindChargeImpact <= explosionWindow;
+    }
+
     protected boolean hasInstabilityCooldown(PlayerCache cache, long time, long cooldownWindow) {
         long climbingTransitionWindow = Math.min(cooldownWindow, 250);
         long stateChangeWindow = Math.min(cooldownWindow, 400);

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/MovementCheck.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/MovementCheck.java
@@ -53,7 +53,7 @@ public abstract class MovementCheck extends Check {
         try {
             ConnectionStability stability = ConnectionStabilityListener.getConnectionStability(player);
             return stability != null ? stability : ConnectionStability.HIGH;
-        } catch (RuntimeException ignored) {
+        } catch (RuntimeException | LinkageError ignored) {
             return ConnectionStability.HIGH;
         }
     }
@@ -84,12 +84,16 @@ public abstract class MovementCheck extends Check {
 
     protected boolean hasInstabilityCooldown(PlayerCache cache, long time, long cooldownWindow) {
         long climbingTransitionWindow = Math.min(cooldownWindow, 250);
+        long stateChangeWindow = Math.min(cooldownWindow, 400);
         return time - cache.lastWindCharge <= cooldownWindow ||
                 time - cache.lastWindChargeReceive <= cooldownWindow ||
                 time - cache.lastWindBurst <= cooldownWindow ||
                 time - cache.lastWindBurstNotVanilla <= cooldownWindow + 400 ||
                 time - cache.lastClimbingTransition <= climbingTransitionWindow ||
-                time - cache.lastTeleport <= cooldownWindow;
+                time - cache.lastTeleport <= cooldownWindow ||
+                time - cache.lastWorldChange <= stateChangeWindow ||
+                time - cache.lastRespawn <= stateChangeWindow ||
+                time - cache.lastGamemodeChange <= stateChangeWindow;
     }
 
     public boolean isPingGlidingPossible(Player player, PlayerCache cache) {

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/boat/BoatA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/boat/BoatA.java
@@ -16,7 +16,7 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Boat;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -80,8 +80,7 @@ public class BoatA extends MovementCheck implements Listener {
             return;
         }
 
-        if (boat.getType() != EntityType.BOAT &&
-                !boat.getType().name().equalsIgnoreCase("CHEST_BOAT")) {
+        if (!(boat instanceof Boat)) {
             buffer.put("boatFlightEvents", 0);
             return;
         }
@@ -210,8 +209,7 @@ public class BoatA extends MovementCheck implements Listener {
             return;
         }
 
-        if (boat.getType() != EntityType.BOAT &&
-                !boat.getType().name().equalsIgnoreCase("CHEST_BOAT")) {
+        if (!(boat instanceof Boat)) {
             buffer.put("boatSpeedEvents", 0);
             buffer.put("previousLocation", event.getFrom());
             return;

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/boat/BoatA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/boat/BoatA.java
@@ -54,7 +54,8 @@ public class BoatA extends MovementCheck implements Listener {
                 time - cache.lastWasHit > 300 && time - cache.lastWasDamaged > 150 &&
                 time - cache.lastKbVelocity > 250 && time - cache.lastAirKbVelocity > 500 &&
                 time - cache.lastStrongKbVelocity > 1250 && time - cache.lastStrongAirKbVelocity > 2500 &&
-                time - cache.lastFlight > 750;
+                time - cache.lastFlight > 750 &&
+                !hasRecent121MobilityBoost(cache, time, false);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/boat/BoatA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/boat/BoatA.java
@@ -45,7 +45,7 @@ public class BoatA extends MovementCheck implements Listener {
                 cache.glidingTicks >= -3 || cache.riptidingTicks >= -5)
             return false;
         long time = System.currentTimeMillis();
-        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, 450);
         return time - cache.lastKnockback > 500 && time - cache.lastKnockbackNotVanilla > 2000 &&
                 time - cache.lastWasFished > 3000 && time - cache.lastTeleport > 500 &&
                 time - cache.lastRespawn > 500 &&

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/boat/BoatA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/boat/BoatA.java
@@ -45,6 +45,7 @@ public class BoatA extends MovementCheck implements Listener {
                 cache.glidingTicks >= -3 || cache.riptidingTicks >= -5)
             return false;
         long time = System.currentTimeMillis();
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
         return time - cache.lastKnockback > 500 && time - cache.lastKnockbackNotVanilla > 2000 &&
                 time - cache.lastWasFished > 3000 && time - cache.lastTeleport > 500 &&
                 time - cache.lastRespawn > 500 &&
@@ -55,7 +56,8 @@ public class BoatA extends MovementCheck implements Listener {
                 time - cache.lastKbVelocity > 250 && time - cache.lastAirKbVelocity > 500 &&
                 time - cache.lastStrongKbVelocity > 1250 && time - cache.lastStrongAirKbVelocity > 2500 &&
                 time - cache.lastFlight > 750 &&
-                !hasRecent121MobilityBoost(cache, time, false);
+                !hasRecent121MobilityBoost(cache, time, false) &&
+                !hasInstabilityCooldown(cache, time, instabilityGrace);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/elytra/ElytraA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/elytra/ElytraA.java
@@ -36,6 +36,7 @@ public class ElytraA extends MovementCheck implements Listener {
         if (cache.flyingTicks >= -5 || cache.climbingTicks >= -2 || cache.glidingTicks <= 3)
             return false;
         long time = System.currentTimeMillis();
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
         return time - cache.lastInsideVehicle > 150 && time - cache.lastInWater > 150 &&
                 time - cache.lastKnockback > 750 && time - cache.lastKnockbackNotVanilla > 3000 &&
                 time - cache.lastWasFished > 4000 && time - cache.lastTeleport > 500 &&
@@ -49,7 +50,8 @@ public class ElytraA extends MovementCheck implements Listener {
                 time - cache.lastKbVelocity > 500 && time - cache.lastAirKbVelocity > 1000 &&
                 time - cache.lastStrongKbVelocity > 2500 && time - cache.lastStrongAirKbVelocity > 5000 &&
                 time - cache.lastFlight > 750 &&
-                !hasRecent121MobilityBoost(cache, time, true);
+                !hasRecent121MobilityBoost(cache, time, true) &&
+                !hasInstabilityCooldown(cache, time, instabilityGrace);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/elytra/ElytraA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/elytra/ElytraA.java
@@ -36,7 +36,7 @@ public class ElytraA extends MovementCheck implements Listener {
         if (cache.flyingTicks >= -5 || cache.climbingTicks >= -2 || cache.glidingTicks <= 3)
             return false;
         long time = System.currentTimeMillis();
-        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, 450);
         return time - cache.lastInsideVehicle > 150 && time - cache.lastInWater > 150 &&
                 time - cache.lastKnockback > 750 && time - cache.lastKnockbackNotVanilla > 3000 &&
                 time - cache.lastWasFished > 4000 && time - cache.lastTeleport > 500 &&

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/elytra/ElytraA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/elytra/ElytraA.java
@@ -48,7 +48,8 @@ public class ElytraA extends MovementCheck implements Listener {
                 time - cache.lastWasHit > 350 && time - cache.lastWasDamaged > 150 &&
                 time - cache.lastKbVelocity > 500 && time - cache.lastAirKbVelocity > 1000 &&
                 time - cache.lastStrongKbVelocity > 2500 && time - cache.lastStrongAirKbVelocity > 5000 &&
-                time - cache.lastFlight > 750;
+                time - cache.lastFlight > 750 &&
+                !hasRecent121MobilityBoost(cache, time, true);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/elytra/ElytraB.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/elytra/ElytraB.java
@@ -47,7 +47,8 @@ public class ElytraB extends MovementCheck implements Listener {
                 time - cache.lastWasHit > 350 && time - cache.lastWasDamaged > 150 &&
                 time - cache.lastKbVelocity > 500 && time - cache.lastAirKbVelocity > 1000 &&
                 time - cache.lastStrongKbVelocity > 2500 && time - cache.lastStrongAirKbVelocity > 5000 &&
-                time - cache.lastFlight > 750;
+                time - cache.lastFlight > 750 &&
+                !hasRecent121MobilityBoost(cache, time, true);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/elytra/ElytraB.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/elytra/ElytraB.java
@@ -35,7 +35,7 @@ public class ElytraB extends MovementCheck implements Listener {
         if (cache.flyingTicks >= -5 || cache.climbingTicks >= -2 || cache.glidingTicks <= 3)
             return false;
         long time = System.currentTimeMillis();
-        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, 450);
         return time - cache.lastInsideVehicle > 150 && time - cache.lastInWater > 150 &&
                 time - cache.lastKnockback > 750 && time - cache.lastKnockbackNotVanilla > 3000 &&
                 time - cache.lastWasFished > 4000 && time - cache.lastTeleport > 500 &&

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/elytra/ElytraB.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/elytra/ElytraB.java
@@ -35,6 +35,7 @@ public class ElytraB extends MovementCheck implements Listener {
         if (cache.flyingTicks >= -5 || cache.climbingTicks >= -2 || cache.glidingTicks <= 3)
             return false;
         long time = System.currentTimeMillis();
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
         return time - cache.lastInsideVehicle > 150 && time - cache.lastInWater > 150 &&
                 time - cache.lastKnockback > 750 && time - cache.lastKnockbackNotVanilla > 3000 &&
                 time - cache.lastWasFished > 4000 && time - cache.lastTeleport > 500 &&
@@ -48,7 +49,8 @@ public class ElytraB extends MovementCheck implements Listener {
                 time - cache.lastKbVelocity > 500 && time - cache.lastAirKbVelocity > 1000 &&
                 time - cache.lastStrongKbVelocity > 2500 && time - cache.lastStrongAirKbVelocity > 5000 &&
                 time - cache.lastFlight > 750 &&
-                !hasRecent121MobilityBoost(cache, time, true);
+                !hasRecent121MobilityBoost(cache, time, true) &&
+                !hasInstabilityCooldown(cache, time, instabilityGrace);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/elytra/ElytraC.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/elytra/ElytraC.java
@@ -80,6 +80,13 @@ public class ElytraC extends MovementCheck implements Listener {
             return;
         }
 
+        int ping = lacPlayer.getPing();
+        if (ping >= 180 && cache.glidingTicks <= 12) {
+            buffer.put("glidingEvents", 0);
+            buffer.put("elytraFlags", 0);
+            return;
+        }
+
         if (!event.isToWithinBlocksPassable() || !event.isFromWithinBlocksPassable()) {
             buffer.put("glidingEvents", 0);
             buffer.put("elytraFlags", 0);
@@ -138,7 +145,8 @@ public class ElytraC extends MovementCheck implements Listener {
         double horizontalSpeed = distanceHorizontal(event.getFrom(), event.getTo());
         double averageHorizontalSpeed = distanceHorizontal(cache.history.onEvent.location.get(HistoryElement.FIRST), event.getTo()) / 2.0;
 
-        if (Math.min(horizontalSpeed, averageHorizontalSpeed) < Math.max(maxTickSpeed, maxEventSpeed) * 1.6 + 0.35)
+        double pingAllowance = Math.min(Math.max((ping - 120) / 240.0, 0.0), 0.35);
+        if (Math.min(horizontalSpeed, averageHorizontalSpeed) < Math.max(maxTickSpeed, maxEventSpeed) * (1.6 + pingAllowance) + 0.35 + pingAllowance)
             return;
 
         Scheduler.runTask(true, () -> {

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/elytra/ElytraC.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/elytra/ElytraC.java
@@ -54,7 +54,8 @@ public class ElytraC extends MovementCheck implements Listener {
                 time - cache.lastWasHit > 350 && time - cache.lastWasDamaged > 150 &&
                 time - cache.lastKbVelocity > 500 && time - cache.lastAirKbVelocity > 1000 &&
                 time - cache.lastStrongKbVelocity > 2500 && time - cache.lastStrongAirKbVelocity > 5000 &&
-                time - cache.lastFlight > 750;
+                time - cache.lastFlight > 750 &&
+                !hasRecent121MobilityBoost(cache, time, true);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/elytra/ElytraC.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/elytra/ElytraC.java
@@ -81,7 +81,7 @@ public class ElytraC extends MovementCheck implements Listener {
         }
 
         int ping = lacPlayer.getPing();
-        if (cache.glidingTicks <= 20) {
+        if (cache.glidingTicks <= 14) {
             buffer.put("glidingEvents", 0);
             buffer.put("elytraFlags", 0);
             return;

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/elytra/ElytraC.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/elytra/ElytraC.java
@@ -42,6 +42,7 @@ public class ElytraC extends MovementCheck implements Listener {
         if (cache.flyingTicks >= -5 || cache.climbingTicks >= -2 || cache.glidingTicks <= 3)
             return false;
         long time = System.currentTimeMillis();
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 600);
         return time - cache.lastInsideVehicle > 150 && time - cache.lastInWater > 150 &&
                 time - cache.lastKnockback > 750 && time - cache.lastKnockbackNotVanilla > 3000 &&
                 time - cache.lastWasFished > 4000 && time - cache.lastTeleport > 500 &&
@@ -55,7 +56,8 @@ public class ElytraC extends MovementCheck implements Listener {
                 time - cache.lastKbVelocity > 500 && time - cache.lastAirKbVelocity > 1000 &&
                 time - cache.lastStrongKbVelocity > 2500 && time - cache.lastStrongAirKbVelocity > 5000 &&
                 time - cache.lastFlight > 750 &&
-                !hasRecent121MobilityBoost(cache, time, true);
+                !hasRecent121MobilityBoost(cache, time, true) &&
+                !hasInstabilityCooldown(cache, time, instabilityGrace);
     }
 
     @EventHandler
@@ -67,20 +69,24 @@ public class ElytraC extends MovementCheck implements Listener {
 
         if (!isCheckAllowed(player, lacPlayer, true)) {
             buffer.put("glidingEvents", 0);
+            buffer.put("elytraFlags", 0);
             return;
         }
 
         if (!isConditionAllowed(player, lacPlayer, event)) {
             buffer.put("glidingEvents", 0);
+            buffer.put("elytraFlags", 0);
             return;
         }
 
         if (!event.isToWithinBlocksPassable() || !event.isFromWithinBlocksPassable()) {
             buffer.put("glidingEvents", 0);
+            buffer.put("elytraFlags", 0);
             return;
         }
         if (!event.isToDownBlocksPassable() || !event.isFromDownBlocksPassable()) {
             buffer.put("glidingEvents", 0);
+            buffer.put("elytraFlags", 0);
             return;
         }
 
@@ -91,6 +97,7 @@ public class ElytraC extends MovementCheck implements Listener {
         long currentTime = System.currentTimeMillis();
         if (currentTime - buffer.getLong("effectTime") < 1000) {
             buffer.put("glidingEvents", 0);
+            buffer.put("elytraFlags", 0);
             return;
         }
 
@@ -100,6 +107,7 @@ public class ElytraC extends MovementCheck implements Listener {
                 Block downBlock = block.getRelative(BlockFace.DOWN);
                 if (!isActuallyPassable(downBlock)) {
                     buffer.put("glidingEvents", 0);
+                    buffer.put("elytraFlags", 0);
                     return;
                 }
             }
@@ -113,6 +121,7 @@ public class ElytraC extends MovementCheck implements Listener {
         for (Block block : interactiveBlocks)
             if (!isActuallyPassable(block)) {
                 buffer.put("glidingEvents", 0);
+                buffer.put("elytraFlags", 0);
                 return;
             }
 
@@ -132,6 +141,10 @@ public class ElytraC extends MovementCheck implements Listener {
             return;
 
         Scheduler.runTask(true, () -> {
+            buffer.put("elytraFlags", buffer.getInt("elytraFlags") + 1);
+            int requiredElytraFlags = getConnectionBufferRequirement(lacPlayer, player, 1);
+            if (buffer.getInt("elytraFlags") <= requiredElytraFlags)
+                return;
             callViolationEventIfRepeat(player, lacPlayer, event, buffer, Main.getBufferDurationMils() - 1000L);
         });
     }

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/elytra/ElytraC.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/elytra/ElytraC.java
@@ -57,6 +57,7 @@ public class ElytraC extends MovementCheck implements Listener {
                 time - cache.lastStrongKbVelocity > 2500 && time - cache.lastStrongAirKbVelocity > 5000 &&
                 time - cache.lastFlight > 750 &&
                 !hasRecent121MobilityBoost(cache, time, true) &&
+                !hasRecentMobilityContext(cache, lacPlayer, time, 900, 1500, 1200, 2000, 1600, 2600) &&
                 !hasInstabilityCooldown(cache, time, instabilityGrace);
     }
 

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/elytra/ElytraC.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/elytra/ElytraC.java
@@ -149,6 +149,11 @@ public class ElytraC extends MovementCheck implements Listener {
         if (Math.min(horizontalSpeed, averageHorizontalSpeed) < Math.max(maxTickSpeed, maxEventSpeed) * (1.6 + pingAllowance) + 0.35 + pingAllowance)
             return;
 
+        long now = System.currentTimeMillis();
+        if (now - buffer.getLong("lastElytraSync") < 200L)
+            return;
+        buffer.put("lastElytraSync", now);
+
         Scheduler.runTask(true, () -> {
             buffer.put("elytraFlags", buffer.getInt("elytraFlags") + 1);
             int requiredElytraFlags = getConnectionBufferRequirement(lacPlayer, 1);

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/elytra/ElytraC.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/elytra/ElytraC.java
@@ -42,7 +42,7 @@ public class ElytraC extends MovementCheck implements Listener {
         if (cache.flyingTicks >= -5 || cache.climbingTicks >= -2 || cache.glidingTicks <= 3)
             return false;
         long time = System.currentTimeMillis();
-        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 600);
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, 600);
         return time - cache.lastInsideVehicle > 150 && time - cache.lastInWater > 150 &&
                 time - cache.lastKnockback > 750 && time - cache.lastKnockbackNotVanilla > 3000 &&
                 time - cache.lastWasFished > 4000 && time - cache.lastTeleport > 500 &&
@@ -142,7 +142,7 @@ public class ElytraC extends MovementCheck implements Listener {
 
         Scheduler.runTask(true, () -> {
             buffer.put("elytraFlags", buffer.getInt("elytraFlags") + 1);
-            int requiredElytraFlags = getConnectionBufferRequirement(lacPlayer, player, 1);
+            int requiredElytraFlags = getConnectionBufferRequirement(lacPlayer, 1);
             if (buffer.getInt("elytraFlags") <= requiredElytraFlags)
                 return;
             callViolationEventIfRepeat(player, lacPlayer, event, buffer, Main.getBufferDurationMils() - 1000L);

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/fastclimb/FastClimbA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/fastclimb/FastClimbA.java
@@ -40,6 +40,7 @@ public class FastClimbA extends MovementCheck implements Listener {
                 cache.glidingTicks >= -3 || cache.riptidingTicks >= -3)
             return false;
         long time = System.currentTimeMillis();
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 350);
         return time - cache.lastInsideVehicle > 150 && time - cache.lastInWater > 150 &&
                 time - cache.lastKnockback > 500 && time - cache.lastKnockbackNotVanilla > 2000 &&
                 time - cache.lastWasFished > 4000 && time - cache.lastTeleport > 500 &&
@@ -49,7 +50,8 @@ public class FastClimbA extends MovementCheck implements Listener {
                 time - cache.lastHoneyBlockVertical > 700 && time - cache.lastHoneyBlockHorizontal > 700 &&
                 time - cache.lastWasHit > 250 && time - cache.lastWasDamaged > 100 &&
                 time - cache.lastFlight > 750 &&
-                !hasRecent121MobilityBoost(cache, time, false);
+                !hasRecent121MobilityBoost(cache, time, false) &&
+                !hasInstabilityCooldown(cache, time, instabilityGrace);
     }
 
     @EventHandler
@@ -61,16 +63,19 @@ public class FastClimbA extends MovementCheck implements Listener {
 
         if (!isCheckAllowed(player, lacPlayer, true)) {
             buffer.put("climbingEvents", 0);
+            buffer.put("climbFlags", 0);
             return;
         }
 
         if (!isConditionAllowed(player, lacPlayer, event)) {
             buffer.put("climbingEvents", 0);
+            buffer.put("climbFlags", 0);
             return;
         }
 
         if (FloodgateHook.isBedrockPlayer(player, true)) {
             buffer.put("climbingEvents", 0);
+            buffer.put("climbFlags", 0);
             return;
         }
 
@@ -87,6 +92,7 @@ public class FastClimbA extends MovementCheck implements Listener {
         withinMaterials.addAll(event.getFromWithinMaterials());
         if (withinMaterials.contains(VerUtil.material.get("SCAFFOLDING"))) {
             buffer.put("climbingEvents", 0);
+            buffer.put("climbFlags", 0);
             return;
         }
 
@@ -152,6 +158,10 @@ public class FastClimbA extends MovementCheck implements Listener {
         }
 
         Scheduler.runTask(true, () -> {
+            buffer.put("climbFlags", buffer.getInt("climbFlags") + 1);
+            int requiredClimbFlags = getConnectionBufferRequirement(lacPlayer, player, 1);
+            if (buffer.getInt("climbFlags") <= requiredClimbFlags)
+                return;
             callViolationEvent(player, lacPlayer, event);
         });
     }

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/fastclimb/FastClimbA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/fastclimb/FastClimbA.java
@@ -48,7 +48,8 @@ public class FastClimbA extends MovementCheck implements Listener {
                 time - cache.lastSlimeBlockVertical > 1000 && time - cache.lastSlimeBlockHorizontal > 1000 &&
                 time - cache.lastHoneyBlockVertical > 700 && time - cache.lastHoneyBlockHorizontal > 700 &&
                 time - cache.lastWasHit > 250 && time - cache.lastWasDamaged > 100 &&
-                time - cache.lastFlight > 750;
+                time - cache.lastFlight > 750 &&
+                !hasRecent121MobilityBoost(cache, time, false);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/fastclimb/FastClimbA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/fastclimb/FastClimbA.java
@@ -40,7 +40,7 @@ public class FastClimbA extends MovementCheck implements Listener {
                 cache.glidingTicks >= -3 || cache.riptidingTicks >= -3)
             return false;
         long time = System.currentTimeMillis();
-        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 350);
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, 350);
         return time - cache.lastInsideVehicle > 150 && time - cache.lastInWater > 150 &&
                 time - cache.lastKnockback > 500 && time - cache.lastKnockbackNotVanilla > 2000 &&
                 time - cache.lastWasFished > 4000 && time - cache.lastTeleport > 500 &&
@@ -159,7 +159,7 @@ public class FastClimbA extends MovementCheck implements Listener {
 
         Scheduler.runTask(true, () -> {
             buffer.put("climbFlags", buffer.getInt("climbFlags") + 1);
-            int requiredClimbFlags = getConnectionBufferRequirement(lacPlayer, player, 1);
+            int requiredClimbFlags = getConnectionBufferRequirement(lacPlayer, 1);
             if (buffer.getInt("climbFlags") <= requiredClimbFlags)
                 return;
             callViolationEvent(player, lacPlayer, event);

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/flight/FlightA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/flight/FlightA.java
@@ -75,8 +75,7 @@ public class FlightA extends MovementCheck implements Listener {
                 time - cache.lastStrongKbVelocity > 5000 && time - cache.lastStrongAirKbVelocity > 15 * 1000 &&
                 time - cache.lastFlight > 750 &&
                 time - cache.lastGliding > 2000 && time - cache.lastRiptiding > 3500 &&
-                time - cache.lastWindCharge > 1000 && time - cache.lastWindChargeReceive > 500 &&
-                time - cache.lastWindBurst > 1500 && time - cache.lastWindBurstNotVanilla > 4000;
+                !hasRecent121MobilityBoost(cache, time, true);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/flight/FlightA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/flight/FlightA.java
@@ -77,6 +77,7 @@ public class FlightA extends MovementCheck implements Listener {
                 time - cache.lastFlight > 750 &&
                 time - cache.lastGliding > 2000 && time - cache.lastRiptiding > 3500 &&
                 !hasRecent121MobilityBoost(cache, time, true) &&
+                !hasRecentMobilityContext(cache, lacPlayer, time, 900, 1500, 1200, 2000, 1600, 2600) &&
                 !hasInstabilityCooldown(cache, time, instabilityGrace);
     }
 

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/flight/FlightA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/flight/FlightA.java
@@ -62,6 +62,7 @@ public class FlightA extends MovementCheck implements Listener {
                 cache.glidingTicks >= -3 || cache.riptidingTicks >= -5)
             return false;
         long time = System.currentTimeMillis();
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
         return time - cache.lastInsideVehicle > 150 && time - cache.lastInWater > 150 &&
                 time - cache.lastKnockback > 750 && time - cache.lastKnockbackNotVanilla > 3000 &&
                 time - cache.lastWasFished > 4000 && time - cache.lastTeleport > 700 &&
@@ -75,7 +76,8 @@ public class FlightA extends MovementCheck implements Listener {
                 time - cache.lastStrongKbVelocity > 5000 && time - cache.lastStrongAirKbVelocity > 15 * 1000 &&
                 time - cache.lastFlight > 750 &&
                 time - cache.lastGliding > 2000 && time - cache.lastRiptiding > 3500 &&
-                !hasRecent121MobilityBoost(cache, time, true);
+                !hasRecent121MobilityBoost(cache, time, true) &&
+                !hasInstabilityCooldown(cache, time, instabilityGrace);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/flight/FlightA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/flight/FlightA.java
@@ -141,10 +141,10 @@ public class FlightA extends MovementCheck implements Listener {
         buffer.put("flightTicks", buffer.getInt("flightTicks") + 1);
         int fallingTicks = buffer.getInt("flightTicks");
 
-        int slowFallingEffectAmplifier = getEffectAmplifier(lacPlayer.cache, PotionEffectType.JUMP);
+        int slowFallingEffectAmplifier = getEffectAmplifier(lacPlayer.cache, PotionEffectType.JUMP_BOOST);
         if (getItemStackAttributes(player, "GENERIC_GRAVITY") != 0)
             slowFallingEffectAmplifier += 1;
-        int jumpEffectAmplifier = getEffectAmplifier(lacPlayer.cache, PotionEffectType.JUMP);
+        int jumpEffectAmplifier = getEffectAmplifier(lacPlayer.cache, PotionEffectType.JUMP_BOOST);
 
         double attributeAmount = Math.max(
                 getItemStackAttributes(player, "GENERIC_JUMP_STRENGTH"),
@@ -289,7 +289,7 @@ public class FlightA extends MovementCheck implements Listener {
 
         if (getEffectAmplifier(lacPlayer.cache, VerUtil.potions.get("LEVITATION")) > 0 ||
                 getEffectAmplifier(lacPlayer.cache, VerUtil.potions.get("SLOW_FALLING")) > 1 ||
-                getEffectAmplifier(lacPlayer.cache, PotionEffectType.JUMP) > 6) {
+                getEffectAmplifier(lacPlayer.cache, PotionEffectType.JUMP_BOOST) > 6) {
             Buffer buffer = getBuffer(player, true);
             buffer.put("effectTime", System.currentTimeMillis());
         }

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/flight/FlightA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/flight/FlightA.java
@@ -62,7 +62,7 @@ public class FlightA extends MovementCheck implements Listener {
                 cache.glidingTicks >= -3 || cache.riptidingTicks >= -5)
             return false;
         long time = System.currentTimeMillis();
-        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, 450);
         return time - cache.lastInsideVehicle > 150 && time - cache.lastInWater > 150 &&
                 time - cache.lastKnockback > 750 && time - cache.lastKnockbackNotVanilla > 3000 &&
                 time - cache.lastWasFished > 4000 && time - cache.lastTeleport > 700 &&

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/flight/FlightB.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/flight/FlightB.java
@@ -50,6 +50,7 @@ public class FlightB extends MovementCheck implements Listener {
                 cache.glidingTicks >= -3 || cache.riptidingTicks >= -5)
             return false;
         long time = System.currentTimeMillis();
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
         return time - cache.lastInsideVehicle > 150 && time - cache.lastInWater > 150 &&
                 time - cache.lastKnockback > 750 && time - cache.lastKnockbackNotVanilla > 3000 &&
                 time - cache.lastWasFished > 4000 && time - cache.lastTeleport > 700 &&
@@ -63,7 +64,8 @@ public class FlightB extends MovementCheck implements Listener {
                 time - cache.lastStrongKbVelocity > 5000 && time - cache.lastStrongAirKbVelocity > 15 * 1000 &&
                 time - cache.lastFlight > 750 &&
                 time - cache.lastGliding > 2000 && time - cache.lastRiptiding > 3500 &&
-                !hasRecent121MobilityBoost(cache, time, true);
+                !hasRecent121MobilityBoost(cache, time, true) &&
+                !hasInstabilityCooldown(cache, time, instabilityGrace);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/flight/FlightB.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/flight/FlightB.java
@@ -50,7 +50,7 @@ public class FlightB extends MovementCheck implements Listener {
                 cache.glidingTicks >= -3 || cache.riptidingTicks >= -5)
             return false;
         long time = System.currentTimeMillis();
-        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, 450);
         return time - cache.lastInsideVehicle > 150 && time - cache.lastInWater > 150 &&
                 time - cache.lastKnockback > 750 && time - cache.lastKnockbackNotVanilla > 3000 &&
                 time - cache.lastWasFished > 4000 && time - cache.lastTeleport > 700 &&

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/flight/FlightB.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/flight/FlightB.java
@@ -191,7 +191,7 @@ public class FlightB extends MovementCheck implements Listener {
             }
         }
 
-        if (getEffectAmplifier(cache, PotionEffectType.JUMP) == 0 &&
+        if (getEffectAmplifier(cache, PotionEffectType.JUMP_BOOST) == 0 &&
                 currentTime - buffer.getLong("justEffectTime") < 100) {
             updateStartLocation(event.getTo(), false, 0.0, buffer);
             buffer.put("flightTicks", 0);
@@ -209,7 +209,7 @@ public class FlightB extends MovementCheck implements Listener {
         }
 
         double height = distanceVertical(buffer.getLocation("startLocation"), event.getTo());
-        int jumpEffectAmplifier = getEffectAmplifier(cache, PotionEffectType.JUMP);
+        int jumpEffectAmplifier = getEffectAmplifier(cache, PotionEffectType.JUMP_BOOST);
         if (jumpEffectAmplifier > 2)
             height -= (jumpEffectAmplifier - 2) * 0.2;
         height = height * 0.9 - 0.1 - buffer.getInt("interactiveOffset");
@@ -302,10 +302,10 @@ public class FlightB extends MovementCheck implements Listener {
 
 
         if (getEffectAmplifier(lacPlayer.cache, VerUtil.potions.get("LEVITATION")) > 0 ||
-                getEffectAmplifier(lacPlayer.cache, PotionEffectType.JUMP) > 32)
+                getEffectAmplifier(lacPlayer.cache, PotionEffectType.JUMP_BOOST) > 32)
             buffer.put("effectTime", System.currentTimeMillis());
 
-        if (getEffectAmplifier(lacPlayer.cache, PotionEffectType.JUMP) != 0)
+        if (getEffectAmplifier(lacPlayer.cache, PotionEffectType.JUMP_BOOST) != 0)
             buffer.put("justEffectTime", System.currentTimeMillis());
     }
 

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/flight/FlightB.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/flight/FlightB.java
@@ -65,6 +65,7 @@ public class FlightB extends MovementCheck implements Listener {
                 time - cache.lastFlight > 750 &&
                 time - cache.lastGliding > 2000 && time - cache.lastRiptiding > 3500 &&
                 !hasRecent121MobilityBoost(cache, time, true) &&
+                !hasRecentMobilityContext(cache, lacPlayer, time, 900, 1500, 1200, 2000, 1600, 2600) &&
                 !hasInstabilityCooldown(cache, time, instabilityGrace);
     }
 

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/flight/FlightB.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/flight/FlightB.java
@@ -63,8 +63,7 @@ public class FlightB extends MovementCheck implements Listener {
                 time - cache.lastStrongKbVelocity > 5000 && time - cache.lastStrongAirKbVelocity > 15 * 1000 &&
                 time - cache.lastFlight > 750 &&
                 time - cache.lastGliding > 2000 && time - cache.lastRiptiding > 3500 &&
-                time - cache.lastWindCharge > 1000 && time - cache.lastWindChargeReceive > 500 &&
-                time - cache.lastWindBurst > 1500 && time - cache.lastWindBurstNotVanilla > 4000;
+                !hasRecent121MobilityBoost(cache, time, true);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/flight/FlightC.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/flight/FlightC.java
@@ -58,8 +58,7 @@ public class FlightC extends MovementCheck implements Listener {
                 time - cache.lastStrongKbVelocity > 5000 && time - cache.lastStrongAirKbVelocity > 15 * 1000 &&
                 time - cache.lastFlight > 750 &&
                 time - cache.lastGliding > 2000 && time - cache.lastRiptiding > 3500 &&
-                time - cache.lastWindCharge > 1000 && time - cache.lastWindChargeReceive > 500 &&
-                time - cache.lastWindBurst > 1500 && time - cache.lastWindBurstNotVanilla > 4000;
+                !hasRecent121MobilityBoost(cache, time, true);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/flight/FlightC.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/flight/FlightC.java
@@ -240,7 +240,7 @@ public class FlightC extends MovementCheck implements Listener {
 
         if (getEffectAmplifier(lacPlayer.cache, VerUtil.potions.get("LEVITATION")) > 0 ||
                 getEffectAmplifier(lacPlayer.cache, VerUtil.potions.get("SLOW_FALLING")) > 1 ||
-                getEffectAmplifier(lacPlayer.cache, PotionEffectType.JUMP) > 6) {
+                getEffectAmplifier(lacPlayer.cache, PotionEffectType.JUMP_BOOST) > 6) {
             Buffer buffer = getBuffer(player, true);
             long currentTime = System.currentTimeMillis();
             buffer.put("effectTime", currentTime);

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/flight/FlightC.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/flight/FlightC.java
@@ -60,6 +60,7 @@ public class FlightC extends MovementCheck implements Listener {
                 time - cache.lastFlight > 750 &&
                 time - cache.lastGliding > 2000 && time - cache.lastRiptiding > 3500 &&
                 !hasRecent121MobilityBoost(cache, time, true) &&
+                !hasRecentMobilityContext(cache, lacPlayer, time, 900, 1500, 1200, 2000, 1600, 2600) &&
                 !hasInstabilityCooldown(cache, time, instabilityGrace);
     }
 

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/flight/FlightC.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/flight/FlightC.java
@@ -45,7 +45,7 @@ public class FlightC extends MovementCheck implements Listener {
                 cache.glidingTicks >= -3 || cache.riptidingTicks >= -5)
             return false;
         long time = System.currentTimeMillis();
-        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, 450);
         return time - cache.lastInsideVehicle > 150 && time - cache.lastInWater > 150 &&
                 time - cache.lastKnockback > 750 && time - cache.lastKnockbackNotVanilla > 3000 &&
                 time - cache.lastWasFished > 4000 && time - cache.lastTeleport > 700 &&
@@ -140,7 +140,7 @@ public class FlightC extends MovementCheck implements Listener {
         }
 
         buffer.put("flightTicks", buffer.getInt("flightTicks") + 1);
-        int requiredFlightTicks = getConnectionBufferRequirement(lacPlayer, player, 2);
+        int requiredFlightTicks = getConnectionBufferRequirement(lacPlayer, 2);
         if (buffer.getInt("flightTicks") <= requiredFlightTicks)
             return;
         boolean isBedrockPlayer = FloodgateHook.isBedrockPlayer(player, true);
@@ -201,7 +201,7 @@ public class FlightC extends MovementCheck implements Listener {
                 return;
 
             buffer.put("flightFlags", buffer.getInt("flightFlags") + 1);
-            int requiredFlightFlags = getConnectionBufferRequirement(lacPlayer, player, 1);
+            int requiredFlightFlags = getConnectionBufferRequirement(lacPlayer, 1);
             if (buffer.getInt("flightFlags") <= requiredFlightFlags)
                 return;
 

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/jump/JumpA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/jump/JumpA.java
@@ -40,7 +40,7 @@ public class JumpA extends MovementCheck implements Listener {
                 cache.glidingTicks >= -6 || cache.riptidingTicks >= -10)
             return false;
         long time = System.currentTimeMillis();
-        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, 450);
         return time - cache.lastInsideVehicle > 300 && time - cache.lastInWater > 300 &&
                 time - cache.lastKnockback > 750 && time - cache.lastKnockbackNotVanilla > 3000 &&
                 time - cache.lastWasFished > 5000 && time - cache.lastTeleport > 700 &&

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/jump/JumpA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/jump/JumpA.java
@@ -138,20 +138,20 @@ public class JumpA extends MovementCheck implements Listener {
             return false;
 
         if (getEffectAmplifier(cache, PotionEffectType.LEVITATION) > 0 ||
-                getEffectAmplifier(cache, PotionEffectType.JUMP) > 2)
+                getEffectAmplifier(cache, PotionEffectType.JUMP_BOOST) > 2)
             return false;
 
         double velocity = player.getVelocity().getY();
         double vSpeed = distanceVertical(from, to);
-        if (getEffectAmplifier(cache, PotionEffectType.JUMP) == 0) {
+        if (getEffectAmplifier(cache, PotionEffectType.JUMP_BOOST) == 0) {
             if (!(velocity < 0.42 * 1.1 && vSpeed > 0.42 * 1.35 ||
                     vSpeed > 0.42 * 2.55))
                 return false;
-        } else if (getEffectAmplifier(cache, PotionEffectType.JUMP) == 1) {
+        } else if (getEffectAmplifier(cache, PotionEffectType.JUMP_BOOST) == 1) {
             if (!(velocity < 0.52 * 1.1 && vSpeed > 0.52 * 1.35 ||
                     vSpeed > 0.52 * 2.55))
                 return false;
-        } else if (getEffectAmplifier(cache, PotionEffectType.JUMP) == 2) {
+        } else if (getEffectAmplifier(cache, PotionEffectType.JUMP_BOOST) == 2) {
             if (!(velocity < 0.621 * 1.1 && vSpeed > 0.621 * 1.35 ||
                     vSpeed > 0.621 * 2.55))
                 return false;
@@ -176,18 +176,18 @@ public class JumpA extends MovementCheck implements Listener {
             return false;
 
         if (getEffectAmplifier(cache, VerUtil.potions.get("LEVITATION")) > 0 ||
-                getEffectAmplifier(cache, PotionEffectType.JUMP) > 2)
+                getEffectAmplifier(cache, PotionEffectType.JUMP_BOOST) > 2)
             return false;
 
         double velocity = player.getVelocity().getY();
         double vSpeed = distanceVertical(from, to);
-        if (getEffectAmplifier(cache, PotionEffectType.JUMP) == 0) {
+        if (getEffectAmplifier(cache, PotionEffectType.JUMP_BOOST) == 0) {
             if (!(velocity < 0.42 * 1.05 && vSpeed > 0.42 * 1.9))
                 return false;
-        } else if (getEffectAmplifier(cache, PotionEffectType.JUMP) == 1) {
+        } else if (getEffectAmplifier(cache, PotionEffectType.JUMP_BOOST) == 1) {
             if (!(velocity < 0.52 * 1.05 && vSpeed > 0.52 * 1.9))
                 return false;
-        } else if (getEffectAmplifier(cache, PotionEffectType.JUMP) == 2) {
+        } else if (getEffectAmplifier(cache, PotionEffectType.JUMP_BOOST) == 2) {
             if (!(velocity < 0.621 * 1.05 && vSpeed > 0.621 * 1.9))
                 return false;
         }

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/jump/JumpA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/jump/JumpA.java
@@ -40,6 +40,7 @@ public class JumpA extends MovementCheck implements Listener {
                 cache.glidingTicks >= -6 || cache.riptidingTicks >= -10)
             return false;
         long time = System.currentTimeMillis();
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
         return time - cache.lastInsideVehicle > 300 && time - cache.lastInWater > 300 &&
                 time - cache.lastKnockback > 750 && time - cache.lastKnockbackNotVanilla > 3000 &&
                 time - cache.lastWasFished > 5000 && time - cache.lastTeleport > 700 &&
@@ -51,7 +52,8 @@ public class JumpA extends MovementCheck implements Listener {
                 time - cache.lastWasHit > 350 && time - cache.lastWasDamaged > 150 &&
                 time - cache.lastStrongKbVelocity > 5000 && time - cache.lastStrongAirKbVelocity > 10 * 1000 &&
                 time - cache.lastFlight > 1200 &&
-                !hasRecent121MobilityBoost(cache, time, true);
+                !hasRecent121MobilityBoost(cache, time, true) &&
+                !hasInstabilityCooldown(cache, time, instabilityGrace);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/jump/JumpA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/jump/JumpA.java
@@ -53,6 +53,7 @@ public class JumpA extends MovementCheck implements Listener {
                 time - cache.lastStrongKbVelocity > 5000 && time - cache.lastStrongAirKbVelocity > 10 * 1000 &&
                 time - cache.lastFlight > 1200 &&
                 !hasRecent121MobilityBoost(cache, time, true) &&
+                !hasRecentMobilityContext(cache, lacPlayer, time, 900, 1500, 1200, 2000, 1600, 2600) &&
                 !hasInstabilityCooldown(cache, time, instabilityGrace);
     }
 

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/jump/JumpA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/jump/JumpA.java
@@ -51,8 +51,7 @@ public class JumpA extends MovementCheck implements Listener {
                 time - cache.lastWasHit > 350 && time - cache.lastWasDamaged > 150 &&
                 time - cache.lastStrongKbVelocity > 5000 && time - cache.lastStrongAirKbVelocity > 10 * 1000 &&
                 time - cache.lastFlight > 1200 &&
-                time - cache.lastWindCharge > 1000 && time - cache.lastWindChargeReceive > 500 &&
-                time - cache.lastWindBurst > 1500 && time - cache.lastWindBurstNotVanilla > 4000;
+                !hasRecent121MobilityBoost(cache, time, true);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/jump/JumpB.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/jump/JumpB.java
@@ -43,7 +43,7 @@ public class JumpB extends MovementCheck implements Listener {
                 cache.glidingTicks >= -6 || cache.riptidingTicks >= -10)
             return false;
         long time = System.currentTimeMillis();
-        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, 450);
         return time - cache.lastInsideVehicle > 300 && time - cache.lastInWater > 300 &&
                 time - cache.lastKnockback > 750 && time - cache.lastKnockbackNotVanilla > 3000 &&
                 time - cache.lastWasFished > 5000 && time - cache.lastTeleport > 700 &&
@@ -205,7 +205,7 @@ public class JumpB extends MovementCheck implements Listener {
                 return;
 
             buffer.put("jumpFlags", buffer.getInt("jumpFlags") + 1);
-            int requiredJumpFlags = getConnectionBufferRequirement(lacPlayer, player, 1);
+            int requiredJumpFlags = getConnectionBufferRequirement(lacPlayer, 1);
             if (buffer.getInt("jumpFlags") <= requiredJumpFlags)
                 return;
             callViolationEventIfRepeat(player, lacPlayer, event, buffer, Main.getBufferDurationMils() - 1000L);

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/jump/JumpB.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/jump/JumpB.java
@@ -94,7 +94,7 @@ public class JumpB extends MovementCheck implements Listener {
             return;
         }
 
-        int jumpEffectAmplifier = getEffectAmplifier(cache, PotionEffectType.JUMP);
+        int jumpEffectAmplifier = getEffectAmplifier(cache, PotionEffectType.JUMP_BOOST);
         if (getEffectAmplifier(cache, VerUtil.potions.get("LEVITATION")) > 0 ||
                 jumpEffectAmplifier > 5) {
             buffer.put("jumpHeight", 0.0);

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/jump/JumpB.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/jump/JumpB.java
@@ -136,7 +136,7 @@ public class JumpB extends MovementCheck implements Listener {
         }
 
         PlayerCacheHistory<Location> eventHistory = history.onEvent.location;
-        PlayerCacheHistory<Location> packetHistory = history.onEvent.location;
+        PlayerCacheHistory<Location> packetHistory = history.onPacket.location;
         double previousEventSpeed = distanceVertical(eventHistory.get(HistoryElement.FIRST), eventHistory.get(HistoryElement.FROM));
         double eventSpeed = distanceVertical(eventHistory.get(HistoryElement.FROM), event.getTo());
         double previousPacketSpeed = distanceVertical(packetHistory.get(HistoryElement.SECOND), packetHistory.get(HistoryElement.FIRST));

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/jump/JumpB.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/jump/JumpB.java
@@ -54,8 +54,7 @@ public class JumpB extends MovementCheck implements Listener {
                 time - cache.lastWasHit > 350 && time - cache.lastWasDamaged > 150 &&
                 time - cache.lastStrongKbVelocity > 5000 && time - cache.lastStrongAirKbVelocity > 10 * 1000 &&
                 time - cache.lastFlight > 1200 &&
-                time - cache.lastWindCharge > 1000 && time - cache.lastWindChargeReceive > 500 &&
-                time - cache.lastWindBurst > 1500 && time - cache.lastWindBurstNotVanilla > 4000;
+                !hasRecent121MobilityBoost(cache, time, true);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/jump/JumpB.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/jump/JumpB.java
@@ -139,11 +139,13 @@ public class JumpB extends MovementCheck implements Listener {
         PlayerCacheHistory<Location> packetHistory = history.onPacket.location;
         double previousEventSpeed = distanceVertical(eventHistory.get(HistoryElement.FIRST), eventHistory.get(HistoryElement.FROM));
         double eventSpeed = distanceVertical(eventHistory.get(HistoryElement.FROM), event.getTo());
+        // Packet history does not include event#getTo(), so we compare the two latest packet deltas:
+        // SECOND -> FIRST (previous packet delta) and FIRST -> FROM (current packet delta).
         double previousPacketSpeed = distanceVertical(packetHistory.get(HistoryElement.SECOND), packetHistory.get(HistoryElement.FIRST));
-        double packetSpeed = distanceVertical(packetHistory.get(HistoryElement.FIRST), packetHistory.get(HistoryElement.FROM));
+        double currentPacketSpeed = distanceVertical(packetHistory.get(HistoryElement.FIRST), packetHistory.get(HistoryElement.FROM));
 
         if (previousEventSpeed <= 0 || eventSpeed <= 0 || previousEventSpeed < eventSpeed ||
-                previousPacketSpeed <= 0 || packetSpeed <= 0 || previousPacketSpeed < packetSpeed) {
+                previousPacketSpeed <= 0 || currentPacketSpeed <= 0 || previousPacketSpeed < currentPacketSpeed) {
             buffer.put("jumpHeight", 0.0);
             return;
         }

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/jump/JumpB.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/jump/JumpB.java
@@ -56,6 +56,7 @@ public class JumpB extends MovementCheck implements Listener {
                 time - cache.lastStrongKbVelocity > 5000 && time - cache.lastStrongAirKbVelocity > 10 * 1000 &&
                 time - cache.lastFlight > 1200 &&
                 !hasRecent121MobilityBoost(cache, time, true) &&
+                !hasRecentMobilityContext(cache, lacPlayer, time, 900, 1500, 1200, 2000, 1600, 2600) &&
                 !hasInstabilityCooldown(cache, time, instabilityGrace);
     }
 

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/liquidwalk/LiquidWalkA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/liquidwalk/LiquidWalkA.java
@@ -36,7 +36,7 @@ public class LiquidWalkA extends MovementCheck implements Listener {
                 cache.glidingTicks >= -3 || cache.riptidingTicks >= -4)
             return false;
         long time = System.currentTimeMillis();
-        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, 450);
         return time - cache.lastInsideVehicle > 150 && time - cache.lastInWater > 150 &&
                 time - cache.lastKnockback > 250 && time - cache.lastKnockbackNotVanilla > 1000 &&
                 time - cache.lastWasFished > 1000 && time - cache.lastTeleport > 500 &&

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/liquidwalk/LiquidWalkA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/liquidwalk/LiquidWalkA.java
@@ -36,6 +36,7 @@ public class LiquidWalkA extends MovementCheck implements Listener {
                 cache.glidingTicks >= -3 || cache.riptidingTicks >= -4)
             return false;
         long time = System.currentTimeMillis();
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
         return time - cache.lastInsideVehicle > 150 && time - cache.lastInWater > 150 &&
                 time - cache.lastKnockback > 250 && time - cache.lastKnockbackNotVanilla > 1000 &&
                 time - cache.lastWasFished > 1000 && time - cache.lastTeleport > 500 &&
@@ -45,7 +46,8 @@ public class LiquidWalkA extends MovementCheck implements Listener {
                 time - cache.lastHoneyBlockVertical > 3000 && time - cache.lastHoneyBlockHorizontal > 3000 &&
                 time - cache.lastWasHit > 150 && time - cache.lastWasDamaged > 50 &&
                 time - cache.lastFlight > 750 &&
-                !hasRecent121MobilityBoost(cache, time, false);
+                !hasRecent121MobilityBoost(cache, time, false) &&
+                !hasInstabilityCooldown(cache, time, instabilityGrace);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/liquidwalk/LiquidWalkA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/liquidwalk/LiquidWalkA.java
@@ -44,7 +44,8 @@ public class LiquidWalkA extends MovementCheck implements Listener {
                 time - cache.lastSlimeBlockVertical > 3000 && time - cache.lastSlimeBlockHorizontal > 2500 &&
                 time - cache.lastHoneyBlockVertical > 3000 && time - cache.lastHoneyBlockHorizontal > 3000 &&
                 time - cache.lastWasHit > 150 && time - cache.lastWasDamaged > 50 &&
-                time - cache.lastFlight > 750;
+                time - cache.lastFlight > 750 &&
+                !hasRecent121MobilityBoost(cache, time, false);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/liquidwalk/LiquidWalkB.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/liquidwalk/LiquidWalkB.java
@@ -30,6 +30,7 @@ public class LiquidWalkB extends MovementCheck implements Listener {
                 cache.glidingTicks >= -3 || cache.riptidingTicks >= -4)
             return false;
         long time = System.currentTimeMillis();
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
         return time - cache.lastInsideVehicle > 150 && time - cache.lastInWater > 150 &&
                 time - cache.lastKnockback > 250 && time - cache.lastKnockbackNotVanilla > 1000 &&
                 time - cache.lastWasFished > 1000 && time - cache.lastTeleport > 500 &&
@@ -39,7 +40,8 @@ public class LiquidWalkB extends MovementCheck implements Listener {
                 time - cache.lastHoneyBlockVertical > 3000 && time - cache.lastHoneyBlockHorizontal > 3000 &&
                 time - cache.lastWasHit > 150 && time - cache.lastWasDamaged > 50 &&
                 time - cache.lastFlight > 750 &&
-                !hasRecent121MobilityBoost(cache, time, false);
+                !hasRecent121MobilityBoost(cache, time, false) &&
+                !hasInstabilityCooldown(cache, time, instabilityGrace);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/liquidwalk/LiquidWalkB.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/liquidwalk/LiquidWalkB.java
@@ -38,7 +38,8 @@ public class LiquidWalkB extends MovementCheck implements Listener {
                 time - cache.lastSlimeBlockVertical > 3000 && time - cache.lastSlimeBlockHorizontal > 2500 &&
                 time - cache.lastHoneyBlockVertical > 3000 && time - cache.lastHoneyBlockHorizontal > 3000 &&
                 time - cache.lastWasHit > 150 && time - cache.lastWasDamaged > 50 &&
-                time - cache.lastFlight > 750;
+                time - cache.lastFlight > 750 &&
+                !hasRecent121MobilityBoost(cache, time, false);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/liquidwalk/LiquidWalkB.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/liquidwalk/LiquidWalkB.java
@@ -30,7 +30,7 @@ public class LiquidWalkB extends MovementCheck implements Listener {
                 cache.glidingTicks >= -3 || cache.riptidingTicks >= -4)
             return false;
         long time = System.currentTimeMillis();
-        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, 450);
         return time - cache.lastInsideVehicle > 150 && time - cache.lastInWater > 150 &&
                 time - cache.lastKnockback > 250 && time - cache.lastKnockbackNotVanilla > 1000 &&
                 time - cache.lastWasFished > 1000 && time - cache.lastTeleport > 500 &&

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/nofall/NoFallA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/nofall/NoFallA.java
@@ -44,6 +44,7 @@ public class NoFallA extends MovementCheck implements Listener {
                 cache.glidingTicks >= -3 || cache.riptidingTicks >= -5)
             return false;
         long time = System.currentTimeMillis();
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
         return time - cache.lastInsideVehicle > 150 && time - cache.lastInWater > 150 &&
                 time - cache.lastKnockback > 750 && time - cache.lastKnockbackNotVanilla > 3000 &&
                 time - cache.lastWasFished > 4000 && time - cache.lastTeleport > 900 &&
@@ -53,7 +54,8 @@ public class NoFallA extends MovementCheck implements Listener {
                 time - cache.lastHoneyBlockVertical > 2500 && time - cache.lastHoneyBlockHorizontal > 2500 &&
                 time - cache.lastWasHit > 350 && time - cache.lastWasDamaged > 150 &&
                 time - cache.lastFlight > 750 &&
-                !hasRecent121MobilityBoost(cache, time, true);
+                !hasRecent121MobilityBoost(cache, time, true) &&
+                !hasInstabilityCooldown(cache, time, instabilityGrace);
     }
 
     private static final Map<Integer, Float> EVENTS_JUMP_0 = new ConcurrentHashMap<>();

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/nofall/NoFallA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/nofall/NoFallA.java
@@ -179,7 +179,7 @@ public class NoFallA extends MovementCheck implements Listener {
 
         Map<Integer, Float> eventMap;
         Map<Double, Float> distanceMap;
-        int jumpEffectAmplifier = getEffectAmplifier(lacPlayer.cache, PotionEffectType.JUMP);
+        int jumpEffectAmplifier = getEffectAmplifier(lacPlayer.cache, PotionEffectType.JUMP_BOOST);
         switch (jumpEffectAmplifier) {
             case 0:
                 eventMap = EVENTS_JUMP_0;
@@ -262,7 +262,7 @@ public class NoFallA extends MovementCheck implements Listener {
 
         if (getEffectAmplifier(lacPlayer.cache, VerUtil.potions.get("LEVITATION")) > 0 ||
                 getEffectAmplifier(lacPlayer.cache, VerUtil.potions.get("SLOW_FALLING")) > 0 ||
-                getEffectAmplifier(lacPlayer.cache, PotionEffectType.JUMP) > 5) {
+                getEffectAmplifier(lacPlayer.cache, PotionEffectType.JUMP_BOOST) > 5) {
             Buffer buffer = getBuffer(player, true);
             buffer.put("effectTime", System.currentTimeMillis());
         }

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/nofall/NoFallA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/nofall/NoFallA.java
@@ -52,7 +52,8 @@ public class NoFallA extends MovementCheck implements Listener {
                 time - cache.lastSlimeBlockVertical > 2500 && time - cache.lastSlimeBlockHorizontal > 2500 &&
                 time - cache.lastHoneyBlockVertical > 2500 && time - cache.lastHoneyBlockHorizontal > 2500 &&
                 time - cache.lastWasHit > 350 && time - cache.lastWasDamaged > 150 &&
-                time - cache.lastFlight > 750;
+                time - cache.lastFlight > 750 &&
+                !hasRecent121MobilityBoost(cache, time, true);
     }
 
     private static final Map<Integer, Float> EVENTS_JUMP_0 = new ConcurrentHashMap<>();

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/nofall/NoFallA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/nofall/NoFallA.java
@@ -44,7 +44,7 @@ public class NoFallA extends MovementCheck implements Listener {
                 cache.glidingTicks >= -3 || cache.riptidingTicks >= -5)
             return false;
         long time = System.currentTimeMillis();
-        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, 450);
         return time - cache.lastInsideVehicle > 150 && time - cache.lastInWater > 150 &&
                 time - cache.lastKnockback > 750 && time - cache.lastKnockbackNotVanilla > 3000 &&
                 time - cache.lastWasFished > 4000 && time - cache.lastTeleport > 900 &&

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/nofall/NoFallB.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/nofall/NoFallB.java
@@ -45,7 +45,8 @@ public class NoFallB extends MovementCheck implements Listener {
                 time - cache.lastSlimeBlockVertical > 2500 && time - cache.lastSlimeBlockHorizontal > 2500 &&
                 time - cache.lastHoneyBlockVertical > 2500 && time - cache.lastHoneyBlockHorizontal > 2500 &&
                 time - cache.lastWasHit > 350 && time - cache.lastWasDamaged > 150 &&
-                time - cache.lastFlight > 750;
+                time - cache.lastFlight > 750 &&
+                !hasRecent121MobilityBoost(cache, time, true);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/nofall/NoFallB.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/nofall/NoFallB.java
@@ -37,7 +37,7 @@ public class NoFallB extends MovementCheck implements Listener {
                 cache.glidingTicks >= -3 || cache.riptidingTicks >= -5)
             return false;
         long time = System.currentTimeMillis();
-        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, 450);
         return time - cache.lastInsideVehicle > 150 && time - cache.lastInWater > 150 &&
                 time - cache.lastKnockback > 750 && time - cache.lastKnockbackNotVanilla > 3000 &&
                 time - cache.lastWasFished > 4000 && time - cache.lastTeleport > 900 &&

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/nofall/NoFallB.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/nofall/NoFallB.java
@@ -129,7 +129,7 @@ public class NoFallB extends MovementCheck implements Listener {
             return;
 
         updateDownBlocks(player, lacPlayer, event.getToDownBlocks());
-        int jumpEffectAmplifier = getEffectAmplifier(lacPlayer.cache, PotionEffectType.JUMP);
+        int jumpEffectAmplifier = getEffectAmplifier(lacPlayer.cache, PotionEffectType.JUMP_BOOST);
         Scheduler.runTask(true, () -> {
             if (jumpEffectAmplifier <= 2) callViolationEventIfRepeat(player, lacPlayer, null, buffer, 3000);
             else callViolationEventIfRepeat(player, lacPlayer, null, buffer, 600);

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/nofall/NoFallB.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/nofall/NoFallB.java
@@ -37,6 +37,7 @@ public class NoFallB extends MovementCheck implements Listener {
                 cache.glidingTicks >= -3 || cache.riptidingTicks >= -5)
             return false;
         long time = System.currentTimeMillis();
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
         return time - cache.lastInsideVehicle > 150 && time - cache.lastInWater > 150 &&
                 time - cache.lastKnockback > 750 && time - cache.lastKnockbackNotVanilla > 3000 &&
                 time - cache.lastWasFished > 4000 && time - cache.lastTeleport > 900 &&
@@ -46,7 +47,8 @@ public class NoFallB extends MovementCheck implements Listener {
                 time - cache.lastHoneyBlockVertical > 2500 && time - cache.lastHoneyBlockHorizontal > 2500 &&
                 time - cache.lastWasHit > 350 && time - cache.lastWasDamaged > 150 &&
                 time - cache.lastFlight > 750 &&
-                !hasRecent121MobilityBoost(cache, time, true);
+                !hasRecent121MobilityBoost(cache, time, true) &&
+                !hasInstabilityCooldown(cache, time, instabilityGrace);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/noslow/NoSlowA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/noslow/NoSlowA.java
@@ -42,7 +42,8 @@ public class NoSlowA extends MovementCheck implements Listener {
                 time - cache.lastWasHit > 350 && time - cache.lastWasDamaged > 150 &&
                 time - cache.lastKbVelocity > 500 && time - cache.lastAirKbVelocity > 1000 &&
                 time - cache.lastStrongKbVelocity > 2500 && time - cache.lastStrongAirKbVelocity > 5000 &&
-                time - cache.lastFlight > 750;
+                time - cache.lastFlight > 750 &&
+                !hasRecent121MobilityBoost(cache, time, false);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/noslow/NoSlowA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/noslow/NoSlowA.java
@@ -32,7 +32,7 @@ public class NoSlowA extends MovementCheck implements Listener {
                 cache.glidingTicks >= -3 || cache.riptidingTicks >= -5)
             return false;
         long time = System.currentTimeMillis();
-        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, 450);
         return time - cache.lastInsideVehicle > 150 && time - cache.lastInWater > 150 &&
                 time - cache.lastKnockback > 750 && time - cache.lastKnockbackNotVanilla > 3000 &&
                 time - cache.lastWasFished > 4000 && time - cache.lastTeleport > 500 &&

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/noslow/NoSlowA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/noslow/NoSlowA.java
@@ -32,6 +32,7 @@ public class NoSlowA extends MovementCheck implements Listener {
                 cache.glidingTicks >= -3 || cache.riptidingTicks >= -5)
             return false;
         long time = System.currentTimeMillis();
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
         return time - cache.lastInsideVehicle > 150 && time - cache.lastInWater > 150 &&
                 time - cache.lastKnockback > 750 && time - cache.lastKnockbackNotVanilla > 3000 &&
                 time - cache.lastWasFished > 4000 && time - cache.lastTeleport > 500 &&
@@ -43,7 +44,8 @@ public class NoSlowA extends MovementCheck implements Listener {
                 time - cache.lastKbVelocity > 500 && time - cache.lastAirKbVelocity > 1000 &&
                 time - cache.lastStrongKbVelocity > 2500 && time - cache.lastStrongAirKbVelocity > 5000 &&
                 time - cache.lastFlight > 750 &&
-                !hasRecent121MobilityBoost(cache, time, false);
+                !hasRecent121MobilityBoost(cache, time, false) &&
+                !hasInstabilityCooldown(cache, time, instabilityGrace);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/noslow/NoSlowA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/noslow/NoSlowA.java
@@ -131,7 +131,7 @@ public class NoSlowA extends MovementCheck implements Listener {
             return;
 
         if (getEffectAmplifier(lacPlayer.cache, VerUtil.potions.get("LEVITATION")) > 0 ||
-                getEffectAmplifier(lacPlayer.cache, PotionEffectType.JUMP) > 5) {
+                getEffectAmplifier(lacPlayer.cache, PotionEffectType.JUMP_BOOST) > 5) {
             Buffer buffer = getBuffer(player, true);
             long currentTime = System.currentTimeMillis();
             buffer.put("effectTime", currentTime);

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedA.java
@@ -131,8 +131,8 @@ public class SpeedA extends MovementCheck implements Listener {
             if (speedEffectAmplifier > 2)
                 maxSpeed *= 1.35;
         }
-        if (getEffectAmplifier(cache, PotionEffectType.JUMP) > 0) {
-            maxSpeed *= getEffectAmplifier(cache, PotionEffectType.JUMP) * 0.25 + 1;
+        if (getEffectAmplifier(cache, PotionEffectType.JUMP_BOOST) > 0) {
+            maxSpeed *= getEffectAmplifier(cache, PotionEffectType.JUMP_BOOST) * 0.25 + 1;
         }
         if (getEffectAmplifier(cache, VerUtil.potions.get("LEVITATION")) > 0) {
             maxSpeed *= getEffectAmplifier(cache, VerUtil.potions.get("LEVITATION")) * 0.20 + 1;
@@ -359,7 +359,7 @@ public class SpeedA extends MovementCheck implements Listener {
             if (speedEffectAmplifier > 2)
                 maxSpeed *= 1.3;
         }
-        int justBoostEffectAmplifier = getEffectAmplifier(lacPlayer.cache, PotionEffectType.JUMP);
+        int justBoostEffectAmplifier = getEffectAmplifier(lacPlayer.cache, PotionEffectType.JUMP_BOOST);
         if (justBoostEffectAmplifier > 0) {
             maxSpeed *= justBoostEffectAmplifier * 0.35 + 1;
             if (justBoostEffectAmplifier > 2)
@@ -407,7 +407,7 @@ public class SpeedA extends MovementCheck implements Listener {
         if (getEffectAmplifier(lacPlayer.cache, PotionEffectType.SPEED) > 5 ||
                 getEffectAmplifier(lacPlayer.cache, VerUtil.potions.get("LEVITATION")) > 0 ||
                 getEffectAmplifier(lacPlayer.cache, VerUtil.potions.get("SLOW_FALLING")) > 1 ||
-                getEffectAmplifier(lacPlayer.cache, PotionEffectType.JUMP) > 5) {
+                getEffectAmplifier(lacPlayer.cache, PotionEffectType.JUMP_BOOST) > 5) {
             Buffer buffer = getBuffer(player, true);
             long currentTime = System.currentTimeMillis();
             buffer.put("airEffectTime", currentTime);

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedA.java
@@ -47,7 +47,7 @@ public class SpeedA extends MovementCheck implements Listener {
                 cache.glidingTicks >= -5 || cache.riptidingTicks >= -6)
             return false;
         long time = System.currentTimeMillis();
-        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, 450);
         return time - cache.lastInsideVehicle > 150 && time - cache.lastInWater > 150 &&
                 time - cache.lastKnockback > 1500 && time - cache.lastKnockbackNotVanilla > 5000 &&
                 time - cache.lastWasFished > 3000 && time - cache.lastTeleport > 600 &&
@@ -255,7 +255,7 @@ public class SpeedA extends MovementCheck implements Listener {
             return;
         }
         long time = System.currentTimeMillis();
-        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, 450);
         boolean conditionAllowed = time - cache.lastInsideVehicle > 150 && time - cache.lastInWater > 150 &&
                 time - cache.lastKnockback > 1500 && time - cache.lastKnockbackNotVanilla > 5000 &&
                 time - cache.lastWasFished > 4000 && time - cache.lastTeleport > 700 &&

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedA.java
@@ -47,6 +47,7 @@ public class SpeedA extends MovementCheck implements Listener {
                 cache.glidingTicks >= -5 || cache.riptidingTicks >= -6)
             return false;
         long time = System.currentTimeMillis();
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
         return time - cache.lastInsideVehicle > 150 && time - cache.lastInWater > 150 &&
                 time - cache.lastKnockback > 1500 && time - cache.lastKnockbackNotVanilla > 5000 &&
                 time - cache.lastWasFished > 3000 && time - cache.lastTeleport > 600 &&
@@ -59,7 +60,8 @@ public class SpeedA extends MovementCheck implements Listener {
                 time - cache.lastStrongKbVelocity > 2500 && time - cache.lastStrongAirKbVelocity > 5000 &&
                 time - cache.lastFlight > 1000 &&
                 time - cache.lastGliding > 750 && time - cache.lastRiptiding > 1500 &&
-                !hasRecent121MobilityBoost(cache, time, false);
+                !hasRecent121MobilityBoost(cache, time, false) &&
+                !hasInstabilityCooldown(cache, time, instabilityGrace);
     }
 
     @EventHandler
@@ -253,6 +255,7 @@ public class SpeedA extends MovementCheck implements Listener {
             return;
         }
         long time = System.currentTimeMillis();
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
         boolean conditionAllowed = time - cache.lastInsideVehicle > 150 && time - cache.lastInWater > 150 &&
                 time - cache.lastKnockback > 1500 && time - cache.lastKnockbackNotVanilla > 5000 &&
                 time - cache.lastWasFished > 4000 && time - cache.lastTeleport > 700 &&
@@ -265,7 +268,8 @@ public class SpeedA extends MovementCheck implements Listener {
                 time - cache.lastKbVelocity > 1000 && time - cache.lastAirKbVelocity > 2000 &&
                 time - cache.lastStrongKbVelocity > 5000 && time - cache.lastStrongAirKbVelocity > 15 * 1000 &&
                 time - cache.lastFlight > 1000 &&
-                time - cache.lastGliding > 2000 && time - cache.lastRiptiding > 3500;
+                time - cache.lastGliding > 2000 && time - cache.lastRiptiding > 3500 &&
+                !hasInstabilityCooldown(cache, time, instabilityGrace);
         if (!conditionAllowed) {
             buffer.put("airSpeedTicks", 0);
             return;

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedA.java
@@ -59,8 +59,7 @@ public class SpeedA extends MovementCheck implements Listener {
                 time - cache.lastStrongKbVelocity > 2500 && time - cache.lastStrongAirKbVelocity > 5000 &&
                 time - cache.lastFlight > 1000 &&
                 time - cache.lastGliding > 750 && time - cache.lastRiptiding > 1500 &&
-                time - cache.lastWindCharge > 500 && time - cache.lastWindChargeReceive > 750 &&
-                time - cache.lastWindBurst > 500 && time - cache.lastWindBurstNotVanilla > 1000;
+                !hasRecent121MobilityBoost(cache, time, false);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedB.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedB.java
@@ -157,7 +157,7 @@ public class SpeedB extends MovementCheck implements Listener {
                 maxSpeed *= 1.35;
         }
         if (!isBlockHeight((float) getBlockY(event.getTo().getY()))) {
-            if (getEffectAmplifier(lacPlayer.cache, PotionEffectType.JUMP) > 0 ||
+            if (getEffectAmplifier(lacPlayer.cache, PotionEffectType.JUMP_BOOST) > 0 ||
                     getEffectAmplifier(lacPlayer.cache, VerUtil.potions.get("LEVITATION")) > 0)
                 return;
             hSpeed -= distanceAbsVertical(event.getFrom(), event.getTo()) * 2.5;

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedB.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedB.java
@@ -54,8 +54,7 @@ public class SpeedB extends MovementCheck implements Listener {
                 time - cache.lastStrongKbVelocity > 2500 && time - cache.lastStrongAirKbVelocity > 5000 &&
                 time - cache.lastFlight > 1000 &&
                 time - cache.lastGliding > 750 && time - cache.lastRiptiding > 1500 &&
-                time - cache.lastWindCharge > 750 && time - cache.lastWindChargeReceive > 875 &&
-                time - cache.lastWindBurst > 500 && time - cache.lastWindBurstNotVanilla > 1000;
+                !hasRecent121MobilityBoost(cache, time, false);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedB.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedB.java
@@ -42,6 +42,7 @@ public class SpeedB extends MovementCheck implements Listener {
                 cache.glidingTicks >= -5 || cache.riptidingTicks >= -6)
             return false;
         long time = System.currentTimeMillis();
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
         return time - cache.lastInsideVehicle > 150 && time - cache.lastInWater > 150 &&
                 time - cache.lastKnockback > 1500 && time - cache.lastKnockbackNotVanilla > 5000 &&
                 time - cache.lastWasFished > 3000 && time - cache.lastTeleport > 600 &&
@@ -54,7 +55,8 @@ public class SpeedB extends MovementCheck implements Listener {
                 time - cache.lastStrongKbVelocity > 2500 && time - cache.lastStrongAirKbVelocity > 5000 &&
                 time - cache.lastFlight > 1000 &&
                 time - cache.lastGliding > 750 && time - cache.lastRiptiding > 1500 &&
-                !hasRecent121MobilityBoost(cache, time, 750, 875, 500, 1000);
+                !hasRecent121MobilityBoost(cache, time, 750, 875, 500, 1000) &&
+                !hasInstabilityCooldown(cache, time, instabilityGrace);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedB.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedB.java
@@ -42,7 +42,7 @@ public class SpeedB extends MovementCheck implements Listener {
                 cache.glidingTicks >= -5 || cache.riptidingTicks >= -6)
             return false;
         long time = System.currentTimeMillis();
-        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, 450);
         return time - cache.lastInsideVehicle > 150 && time - cache.lastInWater > 150 &&
                 time - cache.lastKnockback > 1500 && time - cache.lastKnockbackNotVanilla > 5000 &&
                 time - cache.lastWasFished > 3000 && time - cache.lastTeleport > 600 &&

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedB.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedB.java
@@ -54,7 +54,7 @@ public class SpeedB extends MovementCheck implements Listener {
                 time - cache.lastStrongKbVelocity > 2500 && time - cache.lastStrongAirKbVelocity > 5000 &&
                 time - cache.lastFlight > 1000 &&
                 time - cache.lastGliding > 750 && time - cache.lastRiptiding > 1500 &&
-                !hasRecent121MobilityBoost(cache, time, false);
+                !hasRecent121MobilityBoost(cache, time, 750, 875, 500, 1000);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedC.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedC.java
@@ -164,7 +164,7 @@ public class SpeedC extends MovementCheck implements Listener {
         buffer.put("flags", buffer.getInt("flags") + 1);
         int requiredFlags = getConnectionBufferRequirement(lacPlayer, player, 3);
         long timeSinceEntityNearby = currentTime - lacPlayer.cache.lastEntityNearby;
-        if (timeSinceEntityNearby > 1000)
+        if (timeSinceEntityNearby <= 1000)
             requiredFlags += 1;
         if (buffer.getInt("flags") <= requiredFlags)
             return;

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedC.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedC.java
@@ -61,7 +61,7 @@ public class SpeedC extends MovementCheck implements Listener {
                 time - cache.lastStrongKbVelocity > 5000 && time - cache.lastStrongAirKbVelocity > 15 * 1000 &&
                 time - cache.lastFlight > 1000 &&
                 time - cache.lastGliding > 2000 && time - cache.lastRiptiding > 3500 &&
-                !hasRecent121MobilityBoost(cache, time, true);
+                !hasRecent121MobilityBoost(cache, time, 1000, 1000, 500, 1000);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedC.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedC.java
@@ -163,8 +163,10 @@ public class SpeedC extends MovementCheck implements Listener {
 
         buffer.put("flags", buffer.getInt("flags") + 1);
         int requiredFlags = getConnectionBufferRequirement(lacPlayer, player, 3);
-        if (buffer.getInt("flags") <= requiredFlags && currentTime - lacPlayer.cache.lastEntityNearby > 1000 ||
-                buffer.getInt("flags") <= requiredFlags + 1)
+        long timeSinceEntityNearby = currentTime - lacPlayer.cache.lastEntityNearby;
+        if (timeSinceEntityNearby > 1000)
+            requiredFlags += 1;
+        if (buffer.getInt("flags") <= requiredFlags)
             return;
 
         Set<Player> players = getPlayersForEnchantsSquared(lacPlayer, player);

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedC.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedC.java
@@ -61,8 +61,7 @@ public class SpeedC extends MovementCheck implements Listener {
                 time - cache.lastStrongKbVelocity > 5000 && time - cache.lastStrongAirKbVelocity > 15 * 1000 &&
                 time - cache.lastFlight > 1000 &&
                 time - cache.lastGliding > 2000 && time - cache.lastRiptiding > 3500 &&
-                time - cache.lastWindCharge > 1000 && time - cache.lastWindChargeReceive > 1000 &&
-                time - cache.lastWindBurst > 500 && time - cache.lastWindBurstNotVanilla > 1000;
+                !hasRecent121MobilityBoost(cache, time, true);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedC.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedC.java
@@ -49,6 +49,7 @@ public class SpeedC extends MovementCheck implements Listener {
                 cache.glidingTicks >= -7 || cache.riptidingTicks >= -8)
             return false;
         long time = System.currentTimeMillis();
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 500);
         return time - cache.lastInsideVehicle > 200 && time - cache.lastInWater > 200 &&
                 time - cache.lastKnockback > 1700 && time - cache.lastKnockbackNotVanilla > 6000 &&
                 time - cache.lastWasFished > 4000 && time - cache.lastTeleport > 1000 &&
@@ -61,7 +62,8 @@ public class SpeedC extends MovementCheck implements Listener {
                 time - cache.lastStrongKbVelocity > 5000 && time - cache.lastStrongAirKbVelocity > 15 * 1000 &&
                 time - cache.lastFlight > 1000 &&
                 time - cache.lastGliding > 2000 && time - cache.lastRiptiding > 3500 &&
-                !hasRecent121MobilityBoost(cache, time, 1000, 1000, 500, 1000);
+                !hasRecent121MobilityBoost(cache, time, 1000, 1000, 500, 1000) &&
+                !hasInstabilityCooldown(cache, time, instabilityGrace);
     }
 
     @EventHandler
@@ -73,6 +75,7 @@ public class SpeedC extends MovementCheck implements Listener {
 
         if (!isCheckAllowed(player, lacPlayer, true)) {
             buffer.put("speedTicks", 0);
+            buffer.put("flags", 0);
             return;
         }
 
@@ -86,24 +89,29 @@ public class SpeedC extends MovementCheck implements Listener {
 
         if (!isConditionAllowed(player, lacPlayer, event)) {
             buffer.put("speedTicks", 0);
+            buffer.put("flags", 0);
             return;
         }
 
         long currentTime = System.currentTimeMillis();
         if (currentTime - buffer.getLong("effectTime") <= 2500) {
             buffer.put("speedTicks", 0);
+            buffer.put("flags", 0);
             return;
         }
         if (currentTime - buffer.getLong("impassableTime") < 700) {
             buffer.put("speedTicks", 0);
+            buffer.put("flags", 0);
             return;
         }
         if (currentTime - buffer.getLong("iceTime") < 2000) {
             buffer.put("speedTicks", 0);
+            buffer.put("flags", 0);
             return;
         }
         if (currentTime - buffer.getLong("soulSpeedTime") < 2000) {
             buffer.put("speedTicks", 0);
+            buffer.put("flags", 0);
             return;
         }
 
@@ -154,8 +162,9 @@ public class SpeedC extends MovementCheck implements Listener {
 
 
         buffer.put("flags", buffer.getInt("flags") + 1);
-        if (buffer.getInt("flags") <= 2 && currentTime - lacPlayer.cache.lastEntityNearby > 1000 ||
-                buffer.getInt("flags") <= 3)
+        int requiredFlags = getConnectionBufferRequirement(lacPlayer, player, 3);
+        if (buffer.getInt("flags") <= requiredFlags && currentTime - lacPlayer.cache.lastEntityNearby > 1000 ||
+                buffer.getInt("flags") <= requiredFlags + 1)
             return;
 
         Set<Player> players = getPlayersForEnchantsSquared(lacPlayer, player);

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedC.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedC.java
@@ -49,7 +49,7 @@ public class SpeedC extends MovementCheck implements Listener {
                 cache.glidingTicks >= -7 || cache.riptidingTicks >= -8)
             return false;
         long time = System.currentTimeMillis();
-        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 500);
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, 500);
         return time - cache.lastInsideVehicle > 200 && time - cache.lastInWater > 200 &&
                 time - cache.lastKnockback > 1700 && time - cache.lastKnockbackNotVanilla > 6000 &&
                 time - cache.lastWasFished > 4000 && time - cache.lastTeleport > 1000 &&
@@ -162,7 +162,7 @@ public class SpeedC extends MovementCheck implements Listener {
 
 
         buffer.put("flags", buffer.getInt("flags") + 1);
-        int requiredFlags = getConnectionBufferRequirement(lacPlayer, player, 3);
+        int requiredFlags = getConnectionBufferRequirement(lacPlayer, 3);
         long timeSinceEntityNearby = currentTime - lacPlayer.cache.lastEntityNearby;
         if (timeSinceEntityNearby <= 1000)
             requiredFlags += 1;

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedD.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedD.java
@@ -42,6 +42,7 @@ public class SpeedD extends MovementCheck implements Listener {
                 cache.glidingTicks >= -5 || cache.riptidingTicks >= -6)
             return false;
         long time = System.currentTimeMillis();
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
         return time - cache.lastInsideVehicle > 250 &&
                 time - cache.lastKnockback > 1500 && time - cache.lastKnockbackNotVanilla > 5000 &&
                 time - cache.lastWasFished > 3000 && time - cache.lastTeleport > 600 &&
@@ -54,7 +55,8 @@ public class SpeedD extends MovementCheck implements Listener {
                 time - cache.lastStrongKbVelocity > 2500 && time - cache.lastStrongAirKbVelocity > 5000 &&
                 time - cache.lastFlight > 3000 &&
                 time - cache.lastGliding > 1500 && time - cache.lastRiptiding > 3000 &&
-                !hasRecent121MobilityBoost(cache, time, true);
+                !hasRecent121MobilityBoost(cache, time, true) &&
+                !hasInstabilityCooldown(cache, time, instabilityGrace);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedD.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedD.java
@@ -53,7 +53,8 @@ public class SpeedD extends MovementCheck implements Listener {
                 time - cache.lastKbVelocity > 500 && time - cache.lastAirKbVelocity > 1000 &&
                 time - cache.lastStrongKbVelocity > 2500 && time - cache.lastStrongAirKbVelocity > 5000 &&
                 time - cache.lastFlight > 3000 &&
-                time - cache.lastGliding > 1500 && time - cache.lastRiptiding > 3000;
+                time - cache.lastGliding > 1500 && time - cache.lastRiptiding > 3000 &&
+                !hasRecent121MobilityBoost(cache, time, true);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedD.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedD.java
@@ -42,7 +42,7 @@ public class SpeedD extends MovementCheck implements Listener {
                 cache.glidingTicks >= -5 || cache.riptidingTicks >= -6)
             return false;
         long time = System.currentTimeMillis();
-        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, 450);
         return time - cache.lastInsideVehicle > 250 &&
                 time - cache.lastKnockback > 1500 && time - cache.lastKnockbackNotVanilla > 5000 &&
                 time - cache.lastWasFished > 3000 && time - cache.lastTeleport > 600 &&

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedE.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedE.java
@@ -13,6 +13,7 @@ import me.vekster.lightanticheat.util.hook.plugin.FloodgateHook;
 import me.vekster.lightanticheat.util.scheduler.Scheduler;
 import me.vekster.lightanticheat.version.VerUtil;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Player;
@@ -25,6 +26,7 @@ import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.potion.PotionEffectType;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
  * The absolute horizontal, vertical and absolute speed limiter
@@ -342,11 +344,33 @@ public class SpeedE extends MovementCheck implements Listener {
     }
 
     private boolean isOnIceSurface(LACAsyncPlayerMoveEvent event) {
-        if (event.isToOnIce() || event.isFromOnIce())
-            return true;
+        Set<Block> toDownBlocks = event.getToDownBlocks();
+        if (toDownBlocks != null) {
+            for (Block block : toDownBlocks) {
+                if (block != null && isIce(block.getType()))
+                    return true;
+            }
+        }
+
+        Set<Block> fromDownBlocks = event.getFromDownBlocks();
+        if (fromDownBlocks != null) {
+            for (Block block : fromDownBlocks) {
+                if (block != null && isIce(block.getType()))
+                    return true;
+            }
+        }
+
         return false;
     }
 
+    private boolean isIce(Material material) {
+        if (material == null)
+            return false;
+        return material == VerUtil.material.get("ICE") ||
+                material == VerUtil.material.get("PACKED_ICE") ||
+                material == VerUtil.material.get("BLUE_ICE") ||
+                material == VerUtil.material.get("FROSTED_ICE");
+    }
 
     private boolean isMicroTeleportSuspicious(LACAsyncPlayerMoveEvent event, LACPlayer lacPlayer, PlayerCache cache,
                                               Buffer buffer, double microCapPerTick, double currentJump) {

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedE.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedE.java
@@ -43,7 +43,7 @@ public class SpeedE extends MovementCheck implements Listener {
                 cache.glidingTicks >= -3 || cache.riptidingTicks >= -5)
             return false;
         long time = System.currentTimeMillis();
-        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, 450);
         return time - cache.lastInsideVehicle > 150 && time - cache.lastInWater > 150 &&
                 time - cache.lastKnockback > 750 && time - cache.lastKnockbackNotVanilla > 3000 &&
                 time - cache.lastWasFished > 4000 && time - cache.lastTeleport > 600 &&
@@ -262,7 +262,7 @@ public class SpeedE extends MovementCheck implements Listener {
                 cache.glidingTicks >= -3 || cache.riptidingTicks >= -5)
             return;
         long time = System.currentTimeMillis();
-        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, 450);
         boolean isConditionAllowed = time - cache.lastInsideVehicle > 150 && time - cache.lastInWater > 150 &&
                 time - cache.lastKnockback > 750 && time - cache.lastKnockbackNotVanilla > 3000 &&
                 time - cache.lastWasFished > 4000 && time - cache.lastTeleport > 2500 &&

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedE.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedE.java
@@ -53,7 +53,8 @@ public class SpeedE extends MovementCheck implements Listener {
                 time - cache.lastWasHit > 350 && time - cache.lastWasDamaged > 150 &&
                 time - cache.lastKbVelocity > 250 && time - cache.lastAirKbVelocity > 500 &&
                 time - cache.lastStrongKbVelocity > 1250 && time - cache.lastStrongAirKbVelocity > 2500 &&
-                time - cache.lastFlight > 750;
+                time - cache.lastFlight > 750 &&
+                !hasRecent121MobilityBoost(cache, time, false);
     }
 
     @EventHandler(priority = EventPriority.HIGH)
@@ -269,7 +270,8 @@ public class SpeedE extends MovementCheck implements Listener {
                 time - cache.lastWasHit > 350 && time - cache.lastWasDamaged > 150 &&
                 time - cache.lastKbVelocity > 500 && time - cache.lastAirKbVelocity > 1000 &&
                 time - cache.lastStrongKbVelocity > 2500 && time - cache.lastStrongAirKbVelocity > 5000 &&
-                time - cache.lastFlight > 750;
+                time - cache.lastFlight > 750 &&
+                !hasRecent121MobilityBoost(cache, time, false);
         if (!isConditionAllowed)
             return;
 

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedE.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedE.java
@@ -43,6 +43,7 @@ public class SpeedE extends MovementCheck implements Listener {
                 cache.glidingTicks >= -3 || cache.riptidingTicks >= -5)
             return false;
         long time = System.currentTimeMillis();
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
         return time - cache.lastInsideVehicle > 150 && time - cache.lastInWater > 150 &&
                 time - cache.lastKnockback > 750 && time - cache.lastKnockbackNotVanilla > 3000 &&
                 time - cache.lastWasFished > 4000 && time - cache.lastTeleport > 600 &&
@@ -54,7 +55,8 @@ public class SpeedE extends MovementCheck implements Listener {
                 time - cache.lastKbVelocity > 250 && time - cache.lastAirKbVelocity > 500 &&
                 time - cache.lastStrongKbVelocity > 1250 && time - cache.lastStrongAirKbVelocity > 2500 &&
                 time - cache.lastFlight > 750 &&
-                !hasRecent121MobilityBoost(cache, time, false);
+                !hasRecent121MobilityBoost(cache, time, false) &&
+                !hasInstabilityCooldown(cache, time, instabilityGrace);
     }
 
     @EventHandler(priority = EventPriority.HIGH)
@@ -260,6 +262,7 @@ public class SpeedE extends MovementCheck implements Listener {
                 cache.glidingTicks >= -3 || cache.riptidingTicks >= -5)
             return;
         long time = System.currentTimeMillis();
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
         boolean isConditionAllowed = time - cache.lastInsideVehicle > 150 && time - cache.lastInWater > 150 &&
                 time - cache.lastKnockback > 750 && time - cache.lastKnockbackNotVanilla > 3000 &&
                 time - cache.lastWasFished > 4000 && time - cache.lastTeleport > 2500 &&
@@ -271,7 +274,8 @@ public class SpeedE extends MovementCheck implements Listener {
                 time - cache.lastKbVelocity > 500 && time - cache.lastAirKbVelocity > 1000 &&
                 time - cache.lastStrongKbVelocity > 2500 && time - cache.lastStrongAirKbVelocity > 5000 &&
                 time - cache.lastFlight > 750 &&
-                !hasRecent121MobilityBoost(cache, time, false);
+                !hasRecent121MobilityBoost(cache, time, false) &&
+                !hasInstabilityCooldown(cache, time, instabilityGrace);
         if (!isConditionAllowed)
             return;
 

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedE.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedE.java
@@ -13,7 +13,6 @@ import me.vekster.lightanticheat.util.hook.plugin.FloodgateHook;
 import me.vekster.lightanticheat.util.scheduler.Scheduler;
 import me.vekster.lightanticheat.version.VerUtil;
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Player;
@@ -288,6 +287,9 @@ public class SpeedE extends MovementCheck implements Listener {
                 now - cache.lastGamemodeChange < 600)
             return true;
 
+        if (ignoreRecentTeleportWindows)
+            return false;
+
         int ping = Math.max(lacPlayer.getPing(true), 0);
         long sinceMove = now - buffer.getLong(KEY_LAST_MOVEMENT);
         return ping > 450 || ping > 300 && sinceMove > 450;
@@ -340,21 +342,11 @@ public class SpeedE extends MovementCheck implements Listener {
     }
 
     private boolean isOnIceSurface(LACAsyncPlayerMoveEvent event) {
-        for (Block block : event.getToDownBlocks()) {
-            if (block != null && isIce(block.getType()))
-                return true;
-        }
+        if (event.isToOnIce() || event.isFromOnIce())
+            return true;
         return false;
     }
 
-    private boolean isIce(Material material) {
-        if (material == null)
-            return false;
-        return material == VerUtil.material.get("ICE") ||
-                material == VerUtil.material.get("PACKED_ICE") ||
-                material == VerUtil.material.get("BLUE_ICE") ||
-                material == VerUtil.material.get("FROSTED_ICE");
-    }
 
     private boolean isMicroTeleportSuspicious(LACAsyncPlayerMoveEvent event, LACPlayer lacPlayer, PlayerCache cache,
                                               Buffer buffer, double microCapPerTick, double currentJump) {

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedE.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedE.java
@@ -283,7 +283,7 @@ public class SpeedE extends MovementCheck implements Listener {
 
         if (getEffectAmplifier(cache, VerUtil.potions.get("LEVITATION")) > 1 ||
                 getEffectAmplifier(cache, VerUtil.potions.get("SLOW_FALLING")) > 1 ||
-                getEffectAmplifier(cache, PotionEffectType.JUMP) > 2)
+                getEffectAmplifier(cache, PotionEffectType.JUMP_BOOST) > 2)
             return;
 
         for (int i = 0; i < HistoryElement.values().length; i++) {

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedF.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedF.java
@@ -30,6 +30,7 @@ public class SpeedF extends MovementCheck implements Listener {
                 cache.glidingTicks >= -3 || cache.riptidingTicks >= -5)
             return false;
         long time = System.currentTimeMillis();
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
         return time - cache.lastInsideVehicle > 150 &&
                 time - cache.lastKnockback > 750 && time - cache.lastKnockbackNotVanilla > 3000 &&
                 time - cache.lastWasFished > 4000 && time - cache.lastTeleport > 600 &&
@@ -39,7 +40,8 @@ public class SpeedF extends MovementCheck implements Listener {
                 time - cache.lastHoneyBlockVertical > 2000 && time - cache.lastHoneyBlockHorizontal > 1750 &&
                 time - cache.lastWasHit > 350 && time - cache.lastWasDamaged > 150 &&
                 time - cache.lastFlight > 1500 &&
-                !hasRecent121MobilityBoost(cache, time, false);
+                !hasRecent121MobilityBoost(cache, time, false) &&
+                !hasInstabilityCooldown(cache, time, instabilityGrace);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedF.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedF.java
@@ -30,7 +30,7 @@ public class SpeedF extends MovementCheck implements Listener {
                 cache.glidingTicks >= -3 || cache.riptidingTicks >= -5)
             return false;
         long time = System.currentTimeMillis();
-        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, 450);
         return time - cache.lastInsideVehicle > 150 &&
                 time - cache.lastKnockback > 750 && time - cache.lastKnockbackNotVanilla > 3000 &&
                 time - cache.lastWasFished > 4000 && time - cache.lastTeleport > 600 &&

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedF.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/speed/SpeedF.java
@@ -38,7 +38,8 @@ public class SpeedF extends MovementCheck implements Listener {
                 time - cache.lastSlimeBlockVertical > 4000 && time - cache.lastSlimeBlockHorizontal > 3500 &&
                 time - cache.lastHoneyBlockVertical > 2000 && time - cache.lastHoneyBlockHorizontal > 1750 &&
                 time - cache.lastWasHit > 350 && time - cache.lastWasDamaged > 150 &&
-                time - cache.lastFlight > 1500;
+                time - cache.lastFlight > 1500 &&
+                !hasRecent121MobilityBoost(cache, time, false);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/step/StepA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/step/StepA.java
@@ -42,7 +42,8 @@ public class StepA extends MovementCheck implements Listener {
                 time - cache.lastWasHit > 350 && time - cache.lastWasDamaged > 150 &&
                 time - cache.lastKbVelocity > 250 && time - cache.lastAirKbVelocity > 500 &&
                 time - cache.lastStrongKbVelocity > 1250 && time - cache.lastStrongAirKbVelocity > 2500 &&
-                time - cache.lastFlight > 750;
+                time - cache.lastFlight > 750 &&
+                !hasRecent121MobilityBoost(cache, time, false);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/step/StepA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/step/StepA.java
@@ -32,7 +32,7 @@ public class StepA extends MovementCheck implements Listener {
                 cache.glidingTicks >= -3 || cache.riptidingTicks >= -3)
             return false;
         long time = System.currentTimeMillis();
-        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, 450);
         return time - cache.lastInsideVehicle > 150 && time - cache.lastInWater > 150 &&
                 time - cache.lastKnockback > 750 && time - cache.lastKnockbackNotVanilla > 3000 &&
                 time - cache.lastWasFished > 4000 && time - cache.lastTeleport > 700 &&

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/step/StepA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/step/StepA.java
@@ -32,6 +32,7 @@ public class StepA extends MovementCheck implements Listener {
                 cache.glidingTicks >= -3 || cache.riptidingTicks >= -3)
             return false;
         long time = System.currentTimeMillis();
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
         return time - cache.lastInsideVehicle > 150 && time - cache.lastInWater > 150 &&
                 time - cache.lastKnockback > 750 && time - cache.lastKnockbackNotVanilla > 3000 &&
                 time - cache.lastWasFished > 4000 && time - cache.lastTeleport > 700 &&
@@ -43,7 +44,8 @@ public class StepA extends MovementCheck implements Listener {
                 time - cache.lastKbVelocity > 250 && time - cache.lastAirKbVelocity > 500 &&
                 time - cache.lastStrongKbVelocity > 1250 && time - cache.lastStrongAirKbVelocity > 2500 &&
                 time - cache.lastFlight > 750 &&
-                !hasRecent121MobilityBoost(cache, time, false);
+                !hasRecent121MobilityBoost(cache, time, false) &&
+                !hasInstabilityCooldown(cache, time, instabilityGrace);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/step/StepA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/step/StepA.java
@@ -66,7 +66,7 @@ public class StepA extends MovementCheck implements Listener {
 
         if (getEffectAmplifier(cache, VerUtil.potions.get("LEVITATION")) > 0 ||
                 getEffectAmplifier(cache, VerUtil.potions.get("SLOW_FALLING")) > 1 ||
-                getEffectAmplifier(cache, PotionEffectType.JUMP) > 2)
+                getEffectAmplifier(cache, PotionEffectType.JUMP_BOOST) > 2)
             return;
 
         double vSpeed = distanceVertical(event.getFrom(), event.getTo());

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/trident/TridentA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/trident/TridentA.java
@@ -35,6 +35,7 @@ public class TridentA extends MovementCheck implements Listener {
         if (cache.flyingTicks >= -4 || cache.climbingTicks >= -2)
             return false;
         long time = System.currentTimeMillis();
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
         return time - cache.lastInsideVehicle > 150 &&
                 time - cache.lastKnockback > 500 && time - cache.lastKnockbackNotVanilla > 2000 &&
                 time - cache.lastWasFished > 3000 && time - cache.lastTeleport > 500 &&
@@ -47,7 +48,8 @@ public class TridentA extends MovementCheck implements Listener {
                 time - cache.lastKbVelocity > 500 && time - cache.lastAirKbVelocity > 1000 &&
                 time - cache.lastStrongKbVelocity > 2500 && time - cache.lastStrongAirKbVelocity > 5000 &&
                 time - cache.lastFlight > 750 &&
-                !hasRecent121MobilityBoost(cache, time, false);
+                !hasRecent121MobilityBoost(cache, time, false) &&
+                !hasInstabilityCooldown(cache, time, instabilityGrace);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/trident/TridentA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/trident/TridentA.java
@@ -46,7 +46,8 @@ public class TridentA extends MovementCheck implements Listener {
                 time - cache.lastWasHit > 300 && time - cache.lastWasDamaged > 150 &&
                 time - cache.lastKbVelocity > 500 && time - cache.lastAirKbVelocity > 1000 &&
                 time - cache.lastStrongKbVelocity > 2500 && time - cache.lastStrongAirKbVelocity > 5000 &&
-                time - cache.lastFlight > 750;
+                time - cache.lastFlight > 750 &&
+                !hasRecent121MobilityBoost(cache, time, false);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/trident/TridentA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/trident/TridentA.java
@@ -49,6 +49,7 @@ public class TridentA extends MovementCheck implements Listener {
                 time - cache.lastStrongKbVelocity > 2500 && time - cache.lastStrongAirKbVelocity > 5000 &&
                 time - cache.lastFlight > 750 &&
                 !hasRecent121MobilityBoost(cache, time, false) &&
+                !hasRecentMobilityContext(cache, lacPlayer, time, 900, 1500, 1200, 2000, 1600, 2600) &&
                 !hasInstabilityCooldown(cache, time, instabilityGrace);
     }
 

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/trident/TridentA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/trident/TridentA.java
@@ -35,7 +35,7 @@ public class TridentA extends MovementCheck implements Listener {
         if (cache.flyingTicks >= -4 || cache.climbingTicks >= -2)
             return false;
         long time = System.currentTimeMillis();
-        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, 450);
         return time - cache.lastInsideVehicle > 150 &&
                 time - cache.lastKnockback > 500 && time - cache.lastKnockbackNotVanilla > 2000 &&
                 time - cache.lastWasFished > 3000 && time - cache.lastTeleport > 500 &&

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/trident/TridentA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/trident/TridentA.java
@@ -100,7 +100,7 @@ public class TridentA extends MovementCheck implements Listener {
         }
         ItemStack off = lacPlayer.getItemInOffHand();
         if (off != null && off.getType() == VerUtil.material.get("TRIDENT") &&
-                main.getEnchantmentLevel(VerUtil.enchantment.get("RIPTIDE")) > 3) {
+                off.getEnchantmentLevel(VerUtil.enchantment.get("RIPTIDE")) > 3) {
             return;
         }
 

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/vehicle/VehicleA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/vehicle/VehicleA.java
@@ -35,7 +35,7 @@ public class VehicleA extends MovementCheck implements Listener {
                 cache.glidingTicks >= -3 || cache.riptidingTicks >= -5)
             return false;
         long time = System.currentTimeMillis();
-        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, 450);
         return time - cache.lastKnockback > 500 && time - cache.lastKnockbackNotVanilla > 2000 &&
                 time - cache.lastWasFished > 3000 && time - cache.lastTeleport > 500 &&
                 time - cache.lastRespawn > 500 &&

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/vehicle/VehicleA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/vehicle/VehicleA.java
@@ -35,6 +35,7 @@ public class VehicleA extends MovementCheck implements Listener {
                 cache.glidingTicks >= -3 || cache.riptidingTicks >= -5)
             return false;
         long time = System.currentTimeMillis();
+        long instabilityGrace = getDynamicGraceWindow(lacPlayer, player, 450);
         return time - cache.lastKnockback > 500 && time - cache.lastKnockbackNotVanilla > 2000 &&
                 time - cache.lastWasFished > 3000 && time - cache.lastTeleport > 500 &&
                 time - cache.lastRespawn > 500 &&
@@ -45,7 +46,8 @@ public class VehicleA extends MovementCheck implements Listener {
                 time - cache.lastKbVelocity > 250 && time - cache.lastAirKbVelocity > 500 &&
                 time - cache.lastStrongKbVelocity > 1250 && time - cache.lastStrongAirKbVelocity > 2500 &&
                 time - cache.lastFlight > 750 &&
-                !hasRecent121MobilityBoost(cache, time, false);
+                !hasRecent121MobilityBoost(cache, time, false) &&
+                !hasInstabilityCooldown(cache, time, instabilityGrace);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/movement/vehicle/VehicleA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/movement/vehicle/VehicleA.java
@@ -44,7 +44,8 @@ public class VehicleA extends MovementCheck implements Listener {
                 time - cache.lastWasHit > 300 && time - cache.lastWasDamaged > 150 &&
                 time - cache.lastKbVelocity > 250 && time - cache.lastAirKbVelocity > 500 &&
                 time - cache.lastStrongKbVelocity > 1250 && time - cache.lastStrongAirKbVelocity > 2500 &&
-                time - cache.lastFlight > 750;
+                time - cache.lastFlight > 750 &&
+                !hasRecent121MobilityBoost(cache, time, false);
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/check/checks/packet/timer/TimerA.java
+++ b/src/main/java/me/vekster/lightanticheat/check/checks/packet/timer/TimerA.java
@@ -18,6 +18,17 @@ import org.bukkit.event.Listener;
  * Timer hack
  */
 public class TimerA extends PacketCheck implements Listener {
+
+    private static boolean hasRecent121TimerImpulse(LACPlayer lacPlayer, long currentTime) {
+        int windChargeWindow = 3000;
+        int windChargeReceiveWindow = 1000;
+        if (VerIdentifier.isAtLeastMinecraft(1, 21, 11)) {
+            windChargeWindow += 500;
+            windChargeReceiveWindow += 350;
+        }
+        return currentTime - lacPlayer.cache.lastWindCharge < windChargeWindow ||
+                currentTime - lacPlayer.cache.lastWindChargeReceive < windChargeReceiveWindow;
+    }
     public TimerA() {
         super(CheckName.TIMER_A);
     }
@@ -51,8 +62,7 @@ public class TimerA extends PacketCheck implements Listener {
                 return;
         }
 
-        if (System.currentTimeMillis() - lacPlayer.cache.lastWindCharge < 3000 ||
-                System.currentTimeMillis() - lacPlayer.cache.lastWindChargeReceive < 1000) {
+        if (hasRecent121TimerImpulse(lacPlayer, currentTime)) {
             buffer.put("skipVehiclePacket", !buffer.getBoolean("skipVehiclePacket"));
             if (!buffer.getBoolean("skipVehiclePacket"))
                 return;

--- a/src/main/java/me/vekster/lightanticheat/event/LACEventCaller.java
+++ b/src/main/java/me/vekster/lightanticheat/event/LACEventCaller.java
@@ -27,6 +27,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.plugin.PluginManager;
 import org.jetbrains.annotations.NotNull;
@@ -65,6 +66,9 @@ public class LACEventCaller extends LightInjector implements Listener {
     public static void callEntityDamageEvent(EntityDamageByEntityEvent event) {
         if (!(event.getDamager() instanceof Player))
             return;
+        if (event.getCause() != EntityDamageEvent.DamageCause.ENTITY_ATTACK &&
+                event.getCause() != EntityDamageEvent.DamageCause.ENTITY_SWEEP_ATTACK)
+            return;
         Player player = (Player) event.getDamager();
         if (CheckUtil.isExternalNPC(player))
             return;
@@ -76,7 +80,8 @@ public class LACEventCaller extends LightInjector implements Listener {
                 return;
             PLUGIN_MANAGER.callEvent(new LACPlayerAttackEvent(event, player, lacPlayer, event.getEntity()));
             Scheduler.runTaskAsynchronously(true, () -> {
-                PLUGIN_MANAGER.callEvent(new LACAsyncPlayerAttackEvent(player, lacPlayer, event.getEntity().getEntityId()));
+                PLUGIN_MANAGER.callEvent(new LACAsyncPlayerAttackEvent(player, lacPlayer,
+                        event.getEntity().getEntityId(), event.getCause()));
             });
         });
     }

--- a/src/main/java/me/vekster/lightanticheat/event/playerattack/LACAsyncPlayerAttackEvent.java
+++ b/src/main/java/me/vekster/lightanticheat/event/playerattack/LACAsyncPlayerAttackEvent.java
@@ -5,19 +5,28 @@ import me.vekster.lightanticheat.util.hook.server.folia.FoliaUtil;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.jetbrains.annotations.Nullable;
 
 public class LACAsyncPlayerAttackEvent extends Event {
     private static final HandlerList handlers = new HandlerList();
     private final Player player;
     private final LACPlayer lacPlayer;
     private final int entityId;
+    private final EntityDamageEvent.DamageCause damageCause;
 
     public LACAsyncPlayerAttackEvent(Player player, LACPlayer lacPlayer, int entityId) {
+        this(player, lacPlayer, entityId, null);
+    }
+
+    public LACAsyncPlayerAttackEvent(Player player, LACPlayer lacPlayer, int entityId,
+                                     @Nullable EntityDamageEvent.DamageCause damageCause) {
         super(!FoliaUtil.isFolia());
 
         this.player = player;
         this.lacPlayer = lacPlayer;
         this.entityId = entityId;
+        this.damageCause = damageCause;
     }
 
     public Player getPlayer() {
@@ -30,6 +39,19 @@ public class LACAsyncPlayerAttackEvent extends Event {
 
     public int getEntityId() {
         return entityId;
+    }
+
+    public @Nullable EntityDamageEvent.DamageCause getDamageCause() {
+        return damageCause;
+    }
+
+    public boolean hasDamageCause() {
+        return damageCause != null;
+    }
+
+    public boolean isEntityAttackCause() {
+        return damageCause == EntityDamageEvent.DamageCause.ENTITY_ATTACK ||
+                damageCause == EntityDamageEvent.DamageCause.ENTITY_SWEEP_ATTACK;
     }
 
     public HandlerList getHandlers() {

--- a/src/main/java/me/vekster/lightanticheat/event/playerattack/LACAsyncPlayerAttackEvent.java
+++ b/src/main/java/me/vekster/lightanticheat/event/playerattack/LACAsyncPlayerAttackEvent.java
@@ -50,8 +50,10 @@ public class LACAsyncPlayerAttackEvent extends Event {
     }
 
     public boolean isEntityAttackCause() {
-        return damageCause == EntityDamageEvent.DamageCause.ENTITY_ATTACK ||
-                damageCause == EntityDamageEvent.DamageCause.ENTITY_SWEEP_ATTACK;
+        if (damageCause == null)
+            return false;
+        String causeName = damageCause.name();
+        return causeName.equals("ENTITY_ATTACK") || causeName.equals("ENTITY_SWEEP_ATTACK");
     }
 
     public HandlerList getHandlers() {

--- a/src/main/java/me/vekster/lightanticheat/event/playerattack/LACPlayerAttackEvent.java
+++ b/src/main/java/me/vekster/lightanticheat/event/playerattack/LACPlayerAttackEvent.java
@@ -1,7 +1,6 @@
 package me.vekster.lightanticheat.event.playerattack;
 
 import me.vekster.lightanticheat.player.LACPlayer;
-import me.vekster.lightanticheat.util.detection.CheckUtil;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
@@ -22,7 +21,7 @@ public class LACPlayerAttackEvent extends Event {
         this.player = player;
         this.lacPlayer = lacPlayer;
         this.entity = entity;
-        this.isEntityAttackCause = event.getCause() == EntityDamageEvent.DamageCause.ENTITY_ATTACK;
+        this.isEntityAttackCause = isEntityAttackCause(event.getCause());
     }
 
     public EntityDamageByEntityEvent getEvent() {
@@ -43,6 +42,11 @@ public class LACPlayerAttackEvent extends Event {
 
     public boolean isEntityAttackCause() {
         return isEntityAttackCause;
+    }
+
+    private static boolean isEntityAttackCause(EntityDamageEvent.DamageCause cause) {
+        String causeName = cause.name();
+        return causeName.equals("ENTITY_ATTACK") || causeName.equals("ENTITY_SWEEP_ATTACK");
     }
 
     public HandlerList getHandlers() {

--- a/src/main/java/me/vekster/lightanticheat/event/playerbreakblock/LACAsyncPlayerBreakBlockEvent.java
+++ b/src/main/java/me/vekster/lightanticheat/event/playerbreakblock/LACAsyncPlayerBreakBlockEvent.java
@@ -3,6 +3,7 @@ package me.vekster.lightanticheat.event.playerbreakblock;
 import me.vekster.lightanticheat.player.LACPlayer;
 import me.vekster.lightanticheat.util.hook.server.folia.FoliaUtil;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
@@ -13,6 +14,11 @@ public class LACAsyncPlayerBreakBlockEvent extends Event {
     private Player player;
     private LACPlayer lacPlayer;
     private Block block;
+    private String blockWorld;
+    private int blockX;
+    private int blockY;
+    private int blockZ;
+    private Material blockType;
     private Location location;
     private Location eyeLocation;
 
@@ -22,6 +28,11 @@ public class LACAsyncPlayerBreakBlockEvent extends Event {
         this.player = event.getPlayer();
         this.lacPlayer = event.getLacPlayer();
         this.block = event.getBlock();
+        this.blockWorld = event.getBlock().getWorld().getName();
+        this.blockX = event.getBlock().getX();
+        this.blockY = event.getBlock().getY();
+        this.blockZ = event.getBlock().getZ();
+        this.blockType = event.getBlock().getType();
         this.location = event.getPlayer().getLocation().clone();
         this.eyeLocation = event.getPlayer().getLocation().clone();
     }
@@ -36,6 +47,26 @@ public class LACAsyncPlayerBreakBlockEvent extends Event {
 
     public Block getBlock() {
         return block;
+    }
+
+    public String getBlockWorld() {
+        return blockWorld;
+    }
+
+    public int getBlockX() {
+        return blockX;
+    }
+
+    public int getBlockY() {
+        return blockY;
+    }
+
+    public int getBlockZ() {
+        return blockZ;
+    }
+
+    public Material getBlockType() {
+        return blockType;
     }
 
     public Location getLocation() {

--- a/src/main/java/me/vekster/lightanticheat/event/playerbreakblock/LACAsyncPlayerBreakBlockEvent.java
+++ b/src/main/java/me/vekster/lightanticheat/event/playerbreakblock/LACAsyncPlayerBreakBlockEvent.java
@@ -45,6 +45,10 @@ public class LACAsyncPlayerBreakBlockEvent extends Event {
         return lacPlayer;
     }
 
+    /**
+     * @deprecated Unsafe on Folia async handlers. Use primitive snapshot getters instead.
+     */
+    @Deprecated
     public Block getBlock() {
         return block;
     }

--- a/src/main/java/me/vekster/lightanticheat/event/playerplaceblock/LACAsyncPlayerPlaceBlockEvent.java
+++ b/src/main/java/me/vekster/lightanticheat/event/playerplaceblock/LACAsyncPlayerPlaceBlockEvent.java
@@ -3,6 +3,7 @@ package me.vekster.lightanticheat.event.playerplaceblock;
 import me.vekster.lightanticheat.player.LACPlayer;
 import me.vekster.lightanticheat.util.hook.server.folia.FoliaUtil;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.entity.Player;
@@ -14,6 +15,11 @@ public class LACAsyncPlayerPlaceBlockEvent extends Event {
     private Player player;
     private LACPlayer lacPlayer;
     private Block block;
+    private String blockWorld;
+    private int blockX;
+    private int blockY;
+    private int blockZ;
+    private Material blockType;
     private Block blockAgainst;
     private BlockState blockReplacedState;
     private Location location;
@@ -25,6 +31,11 @@ public class LACAsyncPlayerPlaceBlockEvent extends Event {
         this.player = event.getPlayer();
         this.lacPlayer = event.getLacPlayer();
         this.block = event.getBlock();
+        this.blockWorld = event.getBlock().getWorld().getName();
+        this.blockX = event.getBlock().getX();
+        this.blockY = event.getBlock().getY();
+        this.blockZ = event.getBlock().getZ();
+        this.blockType = event.getBlock().getType();
         this.blockAgainst = event.getBlockAgainst();
         this.blockReplacedState = event.getBlockReplacedState();
         this.location = event.getPlayer().getLocation().clone();
@@ -41,6 +52,26 @@ public class LACAsyncPlayerPlaceBlockEvent extends Event {
 
     public Block getBlock() {
         return block;
+    }
+
+    public String getBlockWorld() {
+        return blockWorld;
+    }
+
+    public int getBlockX() {
+        return blockX;
+    }
+
+    public int getBlockY() {
+        return blockY;
+    }
+
+    public int getBlockZ() {
+        return blockZ;
+    }
+
+    public Material getBlockType() {
+        return blockType;
     }
 
     public Block getBlockAgainst() {

--- a/src/main/java/me/vekster/lightanticheat/event/playerplaceblock/LACAsyncPlayerPlaceBlockEvent.java
+++ b/src/main/java/me/vekster/lightanticheat/event/playerplaceblock/LACAsyncPlayerPlaceBlockEvent.java
@@ -50,6 +50,10 @@ public class LACAsyncPlayerPlaceBlockEvent extends Event {
         return lacPlayer;
     }
 
+    /**
+     * @deprecated Unsafe on Folia async handlers. Use primitive snapshot getters instead.
+     */
+    @Deprecated
     public Block getBlock() {
         return block;
     }

--- a/src/main/java/me/vekster/lightanticheat/player/LACPlayer.java
+++ b/src/main/java/me/vekster/lightanticheat/player/LACPlayer.java
@@ -38,6 +38,10 @@ public class LACPlayer extends VerPlayer {
     public PlayerCooldown cooldown;
     public PlayerViolations violations;
 
+    public UUID getUuid() {
+        return uuid;
+    }
+
     public static LACPlayer getLacPlayer(UUID uuid) {
         return PLAYERS.getOrDefault(uuid, null);
     }

--- a/src/main/java/me/vekster/lightanticheat/player/LACPlayerListener.java
+++ b/src/main/java/me/vekster/lightanticheat/player/LACPlayerListener.java
@@ -726,24 +726,41 @@ public class LACPlayerListener implements Listener {
         Player player = (Player) event.getEntity();
         if (CheckUtil.isExternalNPC(player)) return;
         LACPlayer lacPlayer = LACPlayer.getLacPlayer(player);
+        long currentTime = System.currentTimeMillis();
         if (event.getCause() == EntityDamageEvent.DamageCause.BLOCK_EXPLOSION) {
-            lacPlayer.cache.lastBlockExplosion = System.currentTimeMillis();
+            lacPlayer.cache.lastBlockExplosion = currentTime;
             lacPlayer.cache.vectorOnBlockExplosion = null;
+            lacPlayer.cache.lastWasDamaged = currentTime;
+            lacPlayer.cache.lastKbVelocity = currentTime;
+            lacPlayer.cache.lastAirKbVelocity = currentTime;
+            lacPlayer.cache.vectorOnKbVelocity = null;
+            lacPlayer.cache.vectorOnAirKbVelocity = null;
 
         }
         if (event.getCause() == EntityDamageEvent.DamageCause.ENTITY_EXPLOSION) {
-            lacPlayer.cache.lastEntityExplosion = System.currentTimeMillis();
+            lacPlayer.cache.lastEntityExplosion = currentTime;
             lacPlayer.cache.vectorOnEntityExplosion = null;
+            lacPlayer.cache.lastWasDamaged = currentTime;
+            lacPlayer.cache.lastKbVelocity = currentTime;
+            lacPlayer.cache.lastAirKbVelocity = currentTime;
+            lacPlayer.cache.vectorOnKbVelocity = null;
+            lacPlayer.cache.vectorOnAirKbVelocity = null;
         }
     }
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void lastBlockExplosion(LACAsyncPlayerMoveEvent event) {
         for (CachedEntity cachedEntity : event.getLacPlayer().cache.entitiesNearby)
-            if (cachedEntity.entityType == EntityType.TNT) {
+            if (cachedEntity.entityType == EntityType.TNT || cachedEntity.entityType == EntityType.ENDER_CRYSTAL) {
                 LACPlayer lacPlayer = event.getLacPlayer();
-                lacPlayer.cache.lastBlockExplosion = System.currentTimeMillis();
-                lacPlayer.cache.vectorOnBlockExplosion = null;
+                long currentTime = System.currentTimeMillis();
+                if (cachedEntity.entityType == EntityType.TNT) {
+                    lacPlayer.cache.lastBlockExplosion = currentTime;
+                    lacPlayer.cache.vectorOnBlockExplosion = null;
+                } else {
+                    lacPlayer.cache.lastEntityExplosion = currentTime;
+                    lacPlayer.cache.vectorOnEntityExplosion = null;
+                }
                 return;
             }
     }

--- a/src/main/java/me/vekster/lightanticheat/player/LACPlayerListener.java
+++ b/src/main/java/me/vekster/lightanticheat/player/LACPlayerListener.java
@@ -302,13 +302,13 @@ public class LACPlayerListener implements Listener {
             Arrow arrow = (Arrow) event.getDamager();
             if (arrow.getShooter() instanceof Player) {
                 damager = (Player) arrow.getShooter();
-                enchantment = Enchantment.ARROW_KNOCKBACK;
+                enchantment = Enchantment.PUNCH;
             }
         } else if (event.getDamager().getType() == VerUtil.entityTypes.get("SPECTRAL_ARROW")) {
             ProjectileSource shooter = VerUtil.getSpectralArrowShooter(event.getDamager());
             if (shooter instanceof Player) {
                 damager = (Player) shooter;
-                enchantment = Enchantment.ARROW_KNOCKBACK;
+                enchantment = Enchantment.PUNCH;
             }
         }
         if (damager == null)
@@ -698,7 +698,7 @@ public class LACPlayerListener implements Listener {
     @EventHandler(priority = EventPriority.LOWEST)
     public void lastBlockExplosion(LACAsyncPlayerMoveEvent event) {
         for (CachedEntity cachedEntity : event.getLacPlayer().cache.entitiesNearby)
-            if (cachedEntity.entityType == EntityType.PRIMED_TNT) {
+            if (cachedEntity.entityType == EntityType.TNT) {
                 LACPlayer lacPlayer = event.getLacPlayer();
                 lacPlayer.cache.lastBlockExplosion = System.currentTimeMillis();
                 lacPlayer.cache.vectorOnBlockExplosion = null;

--- a/src/main/java/me/vekster/lightanticheat/player/LACPlayerListener.java
+++ b/src/main/java/me/vekster/lightanticheat/player/LACPlayerListener.java
@@ -17,12 +17,14 @@ import me.vekster.lightanticheat.util.config.ConfigManager;
 import me.vekster.lightanticheat.util.cooldown.CooldownUtil;
 import me.vekster.lightanticheat.util.detection.CheckUtil;
 import me.vekster.lightanticheat.util.detection.LeanTowards;
+import me.vekster.lightanticheat.util.hook.server.folia.FoliaUtil;
 import me.vekster.lightanticheat.util.scheduler.Scheduler;
 import me.vekster.lightanticheat.version.VerPlayer;
 import me.vekster.lightanticheat.version.VerUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.enchantments.Enchantment;
@@ -767,6 +769,11 @@ public class LACPlayerListener implements Listener {
                     asyncPlayers.put(player.getUniqueId(), lacPlayer);
                     PlayerCache cache = lacPlayer.cache;
                     Scheduler.entityThread(player, () -> {
+                        World asyncWorld = AsyncUtil.getWorld(player);
+                        World playerWorld = player.getWorld();
+                        if (!FoliaUtil.isStable(player) || asyncWorld == null || playerWorld == null ||
+                                !asyncWorld.getUID().equals(playerWorld.getUID()))
+                            return;
                         cache.sneakingTicks = increase(player.isSneaking(), cache.sneakingTicks);
                         cache.sprintingTicks = increase(player.isSprinting(), cache.sprintingTicks);
                         cache.swimmingTicks = increase(lacPlayer.isSwimming(), cache.swimmingTicks);

--- a/src/main/java/me/vekster/lightanticheat/player/LACPlayerListener.java
+++ b/src/main/java/me/vekster/lightanticheat/player/LACPlayerListener.java
@@ -79,6 +79,9 @@ public class LACPlayerListener implements Listener {
     }
 
     private static void loadLacPlayer(Player player) {
+        if (!player.isOnline())
+            return;
+
         UUID uuid = player.getUniqueId();
 
         if (!LACPlayer.PLAYERS.containsKey(uuid)) {

--- a/src/main/java/me/vekster/lightanticheat/player/LACPlayerListener.java
+++ b/src/main/java/me/vekster/lightanticheat/player/LACPlayerListener.java
@@ -516,7 +516,7 @@ public class LACPlayerListener implements Listener {
 
         EntityType damagerType = event.getDamager().getType();
         long now = System.currentTimeMillis();
-        if (damagerType == EntityType.ENDER_CRYSTAL)
+        if ("ENDER_CRYSTAL".equals(damagerType.name()))
             lacPlayer.cache.lastEndCrystalImpact = now;
         if (damagerType == VerUtil.entityTypes.get("WIND_CHARGE"))
             lacPlayer.cache.lastWindChargeImpact = now;

--- a/src/main/java/me/vekster/lightanticheat/player/LACPlayerListener.java
+++ b/src/main/java/me/vekster/lightanticheat/player/LACPlayerListener.java
@@ -755,9 +755,7 @@ public class LACPlayerListener implements Listener {
 
         }
         if (event.getCause() == EntityDamageEvent.DamageCause.ENTITY_EXPLOSION) {
-            long now = System.currentTimeMillis();
-            lacPlayer.cache.lastEntityExplosion = now;
-            lacPlayer.cache.lastEndCrystalImpact = now;
+            lacPlayer.cache.lastEntityExplosion = System.currentTimeMillis();
             lacPlayer.cache.vectorOnEntityExplosion = null;
         }
     }
@@ -811,7 +809,9 @@ public class LACPlayerListener implements Listener {
                             }
                             cache.glidingTicks = increase(lacPlayer.isGliding(), cache.glidingTicks);
                             cache.riptidingTicks = increase(lacPlayer.isRiptiding(), cache.riptidingTicks);
-                            boolean hasElytraEquipped = lacPlayer.getArmorPiece(EquipmentSlot.CHEST).getType() == VerUtil.material.get("ELYTRA");
+                            ItemStack chest = lacPlayer.getArmorPiece(EquipmentSlot.CHEST);
+                            Material chestType = chest == null ? Material.AIR : chest.getType();
+                            boolean hasElytraEquipped = chestType == VerUtil.material.get("ELYTRA");
                             if (cache.hadElytraEquipped != hasElytraEquipped) {
                                 if (hasElytraEquipped)
                                     cache.lastElytraEquip = System.currentTimeMillis();

--- a/src/main/java/me/vekster/lightanticheat/player/LACPlayerListener.java
+++ b/src/main/java/me/vekster/lightanticheat/player/LACPlayerListener.java
@@ -751,16 +751,10 @@ public class LACPlayerListener implements Listener {
     @EventHandler(priority = EventPriority.LOWEST)
     public void lastBlockExplosion(LACAsyncPlayerMoveEvent event) {
         for (CachedEntity cachedEntity : event.getLacPlayer().cache.entitiesNearby)
-            if (cachedEntity.entityType == EntityType.TNT || cachedEntity.entityType == EntityType.ENDER_CRYSTAL) {
+            if (cachedEntity.entityType == EntityType.TNT) {
                 LACPlayer lacPlayer = event.getLacPlayer();
-                long currentTime = System.currentTimeMillis();
-                if (cachedEntity.entityType == EntityType.TNT) {
-                    lacPlayer.cache.lastBlockExplosion = currentTime;
-                    lacPlayer.cache.vectorOnBlockExplosion = null;
-                } else {
-                    lacPlayer.cache.lastEntityExplosion = currentTime;
-                    lacPlayer.cache.vectorOnEntityExplosion = null;
-                }
+                lacPlayer.cache.lastBlockExplosion = System.currentTimeMillis();
+                lacPlayer.cache.vectorOnBlockExplosion = null;
                 return;
             }
     }

--- a/src/main/java/me/vekster/lightanticheat/player/LACPlayerListener.java
+++ b/src/main/java/me/vekster/lightanticheat/player/LACPlayerListener.java
@@ -60,9 +60,17 @@ public class LACPlayerListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void onJoin(PlayerJoinEvent event) {
-        Scheduler.entityThread(event.getPlayer(), true, () -> {
-            loadLacPlayer(event.getPlayer());
-        });
+        loadLacPlayer(event.getPlayer());
+    }
+
+    private static LACPlayer getInitializedLacPlayer(Player player) {
+        LACPlayer lacPlayer = LACPlayer.getLacPlayer(player);
+        if (lacPlayer != null && lacPlayer.cache != null)
+            return lacPlayer;
+
+        loadLacPlayer(player);
+        lacPlayer = LACPlayer.getLacPlayer(player);
+        return lacPlayer != null && lacPlayer.cache != null ? lacPlayer : null;
     }
 
     private static void loadLacPlayer(Player player) {
@@ -341,47 +349,65 @@ public class LACPlayerListener implements Listener {
     @EventHandler(priority = EventPriority.HIGH)
     public void lastBlockPlace(LACPlayerPlaceBlockEvent event) {
         Player player = event.getPlayer();
-        LACPlayer lacPlayer = LACPlayer.getLacPlayer(player);
-        lacPlayer.cache.lastBlockPlace = System.currentTimeMillis();
+        Scheduler.entityThread(player, () -> {
+            LACPlayer lacPlayer = getInitializedLacPlayer(player);
+            if (lacPlayer == null || lacPlayer.cache == null) return;
+            lacPlayer.cache.lastBlockPlace = System.currentTimeMillis();
+        });
     }
 
     @EventHandler(priority = EventPriority.HIGH)
     public void lastBlockBreak(LACPlayerBreakBlockEvent event) {
         Player player = event.getPlayer();
-        LACPlayer lacPlayer = LACPlayer.getLacPlayer(player);
-        lacPlayer.cache.lastBlockBreak = System.currentTimeMillis();
+        Scheduler.entityThread(player, () -> {
+            LACPlayer lacPlayer = getInitializedLacPlayer(player);
+            if (lacPlayer == null || lacPlayer.cache == null) return;
+            lacPlayer.cache.lastBlockBreak = System.currentTimeMillis();
+        });
     }
 
     @EventHandler
     public void lastTeleport(PlayerTeleportEvent event) {
         if (CheckUtil.isExternalNPC(event)) return;
         Player player = event.getPlayer();
-        LACPlayer lacPlayer = LACPlayer.getLacPlayer(player);
-        lacPlayer.cache.lastTeleport = System.currentTimeMillis();
+        Scheduler.entityThread(player, () -> {
+            LACPlayer lacPlayer = getInitializedLacPlayer(player);
+            if (lacPlayer == null || lacPlayer.cache == null) return;
+            lacPlayer.cache.lastTeleport = System.currentTimeMillis();
+        });
     }
 
     @EventHandler
     public void lastWorldChange(PlayerChangedWorldEvent event) {
         if (CheckUtil.isExternalNPC(event)) return;
         Player player = event.getPlayer();
-        LACPlayer lacPlayer = LACPlayer.getLacPlayer(player);
-        lacPlayer.cache.lastWorldChange = System.currentTimeMillis();
+        Scheduler.entityThread(player, () -> {
+            LACPlayer lacPlayer = getInitializedLacPlayer(player);
+            if (lacPlayer == null || lacPlayer.cache == null) return;
+            lacPlayer.cache.lastWorldChange = System.currentTimeMillis();
+        });
     }
 
     @EventHandler
     public void lastGamemodeChange(PlayerGameModeChangeEvent event) {
         if (CheckUtil.isExternalNPC(event)) return;
         Player player = event.getPlayer();
-        LACPlayer lacPlayer = LACPlayer.getLacPlayer(player);
-        lacPlayer.cache.lastGamemodeChange = System.currentTimeMillis();
+        Scheduler.entityThread(player, () -> {
+            LACPlayer lacPlayer = getInitializedLacPlayer(player);
+            if (lacPlayer == null || lacPlayer.cache == null) return;
+            lacPlayer.cache.lastGamemodeChange = System.currentTimeMillis();
+        });
     }
 
     @EventHandler
     public void lastRespawn(PlayerRespawnEvent event) {
         if (CheckUtil.isExternalNPC(event)) return;
         Player player = event.getPlayer();
-        LACPlayer lacPlayer = LACPlayer.getLacPlayer(player);
-        lacPlayer.cache.lastRespawn = System.currentTimeMillis();
+        Scheduler.entityThread(player, () -> {
+            LACPlayer lacPlayer = getInitializedLacPlayer(player);
+            if (lacPlayer == null || lacPlayer.cache == null) return;
+            lacPlayer.cache.lastRespawn = System.currentTimeMillis();
+        });
     }
 
     @EventHandler

--- a/src/main/java/me/vekster/lightanticheat/player/LACPlayerListener.java
+++ b/src/main/java/me/vekster/lightanticheat/player/LACPlayerListener.java
@@ -769,21 +769,24 @@ public class LACPlayerListener implements Listener {
                     asyncPlayers.put(player.getUniqueId(), lacPlayer);
                     PlayerCache cache = lacPlayer.cache;
                     Scheduler.entityThread(player, () -> {
-                        World asyncWorld = AsyncUtil.getWorld(player);
-                        World playerWorld = player.getWorld();
-                        if (!FoliaUtil.isStable(player) || asyncWorld == null || playerWorld == null ||
-                                !asyncWorld.getUID().equals(playerWorld.getUID()))
-                            return;
-                        cache.sneakingTicks = increase(player.isSneaking(), cache.sneakingTicks);
-                        cache.sprintingTicks = increase(player.isSprinting(), cache.sprintingTicks);
-                        cache.swimmingTicks = increase(lacPlayer.isSwimming(), cache.swimmingTicks);
-                        cache.climbingTicks = increase(lacPlayer.isClimbing(), cache.climbingTicks);
-                        cache.glidingTicks = increase(lacPlayer.isGliding(), cache.glidingTicks);
-                        cache.riptidingTicks = increase(lacPlayer.isRiptiding(), cache.riptidingTicks);
-                        cache.flyingTicks = increase(player.isFlying(), cache.flyingTicks);
-                        cache.blockingTicks = increase(player.isBlocking(), cache.blockingTicks);
-                        if (player.isInsideVehicle())
-                            cache.lastInsideVehicle = System.currentTimeMillis();
+                        try {
+                            World asyncWorld = AsyncUtil.getWorld(player);
+                            World playerWorld = player.getWorld();
+                            if (!FoliaUtil.isStable(player) || asyncWorld == null || playerWorld == null ||
+                                    !asyncWorld.getUID().equals(playerWorld.getUID()))
+                                return;
+                            cache.sneakingTicks = increase(player.isSneaking(), cache.sneakingTicks);
+                            cache.sprintingTicks = increase(player.isSprinting(), cache.sprintingTicks);
+                            cache.swimmingTicks = increase(lacPlayer.isSwimming(), cache.swimmingTicks);
+                            cache.climbingTicks = increase(lacPlayer.isClimbing(), cache.climbingTicks);
+                            cache.glidingTicks = increase(lacPlayer.isGliding(), cache.glidingTicks);
+                            cache.riptidingTicks = increase(lacPlayer.isRiptiding(), cache.riptidingTicks);
+                            cache.flyingTicks = increase(player.isFlying(), cache.flyingTicks);
+                            cache.blockingTicks = increase(player.isBlocking(), cache.blockingTicks);
+                            if (player.isInsideVehicle())
+                                cache.lastInsideVehicle = System.currentTimeMillis();
+                        } catch (IllegalStateException ignored) {
+                        }
                     });
                 });
                 setAsyncPlayers(asyncPlayers);

--- a/src/main/java/me/vekster/lightanticheat/player/LACPlayerListener.java
+++ b/src/main/java/me/vekster/lightanticheat/player/LACPlayerListener.java
@@ -778,7 +778,12 @@ public class LACPlayerListener implements Listener {
                             cache.sneakingTicks = increase(player.isSneaking(), cache.sneakingTicks);
                             cache.sprintingTicks = increase(player.isSprinting(), cache.sprintingTicks);
                             cache.swimmingTicks = increase(lacPlayer.isSwimming(), cache.swimmingTicks);
+                            int previousClimbingTicks = cache.climbingTicks;
                             cache.climbingTicks = increase(lacPlayer.isClimbing(), cache.climbingTicks);
+                            if (previousClimbingTicks >= 0 && cache.climbingTicks < 0 ||
+                                    previousClimbingTicks < 0 && cache.climbingTicks >= 0) {
+                                cache.lastClimbingTransition = System.currentTimeMillis();
+                            }
                             cache.glidingTicks = increase(lacPlayer.isGliding(), cache.glidingTicks);
                             cache.riptidingTicks = increase(lacPlayer.isRiptiding(), cache.riptidingTicks);
                             cache.flyingTicks = increase(player.isFlying(), cache.flyingTicks);

--- a/src/main/java/me/vekster/lightanticheat/player/LACPlayerListener.java
+++ b/src/main/java/me/vekster/lightanticheat/player/LACPlayerListener.java
@@ -60,10 +60,15 @@ public class LACPlayerListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void onJoin(PlayerJoinEvent event) {
-        loadLacPlayer(event.getPlayer());
+        Scheduler.entityThread(event.getPlayer(), true, () -> {
+            loadLacPlayer(event.getPlayer());
+        });
     }
 
     private static LACPlayer getInitializedLacPlayer(Player player) {
+        if (!player.isOnline())
+            return null;
+
         LACPlayer lacPlayer = LACPlayer.getLacPlayer(player);
         if (lacPlayer != null && lacPlayer.cache != null)
             return lacPlayer;
@@ -349,20 +354,22 @@ public class LACPlayerListener implements Listener {
     @EventHandler(priority = EventPriority.HIGH)
     public void lastBlockPlace(LACPlayerPlaceBlockEvent event) {
         Player player = event.getPlayer();
+        long now = System.currentTimeMillis();
         Scheduler.entityThread(player, () -> {
             LACPlayer lacPlayer = getInitializedLacPlayer(player);
-            if (lacPlayer == null || lacPlayer.cache == null) return;
-            lacPlayer.cache.lastBlockPlace = System.currentTimeMillis();
+            if (lacPlayer == null) return;
+            lacPlayer.cache.lastBlockPlace = now;
         });
     }
 
     @EventHandler(priority = EventPriority.HIGH)
     public void lastBlockBreak(LACPlayerBreakBlockEvent event) {
         Player player = event.getPlayer();
+        long now = System.currentTimeMillis();
         Scheduler.entityThread(player, () -> {
             LACPlayer lacPlayer = getInitializedLacPlayer(player);
-            if (lacPlayer == null || lacPlayer.cache == null) return;
-            lacPlayer.cache.lastBlockBreak = System.currentTimeMillis();
+            if (lacPlayer == null) return;
+            lacPlayer.cache.lastBlockBreak = now;
         });
     }
 
@@ -370,10 +377,11 @@ public class LACPlayerListener implements Listener {
     public void lastTeleport(PlayerTeleportEvent event) {
         if (CheckUtil.isExternalNPC(event)) return;
         Player player = event.getPlayer();
+        long now = System.currentTimeMillis();
         Scheduler.entityThread(player, () -> {
             LACPlayer lacPlayer = getInitializedLacPlayer(player);
-            if (lacPlayer == null || lacPlayer.cache == null) return;
-            lacPlayer.cache.lastTeleport = System.currentTimeMillis();
+            if (lacPlayer == null) return;
+            lacPlayer.cache.lastTeleport = now;
         });
     }
 
@@ -381,10 +389,11 @@ public class LACPlayerListener implements Listener {
     public void lastWorldChange(PlayerChangedWorldEvent event) {
         if (CheckUtil.isExternalNPC(event)) return;
         Player player = event.getPlayer();
+        long now = System.currentTimeMillis();
         Scheduler.entityThread(player, () -> {
             LACPlayer lacPlayer = getInitializedLacPlayer(player);
-            if (lacPlayer == null || lacPlayer.cache == null) return;
-            lacPlayer.cache.lastWorldChange = System.currentTimeMillis();
+            if (lacPlayer == null) return;
+            lacPlayer.cache.lastWorldChange = now;
         });
     }
 
@@ -392,10 +401,11 @@ public class LACPlayerListener implements Listener {
     public void lastGamemodeChange(PlayerGameModeChangeEvent event) {
         if (CheckUtil.isExternalNPC(event)) return;
         Player player = event.getPlayer();
+        long now = System.currentTimeMillis();
         Scheduler.entityThread(player, () -> {
             LACPlayer lacPlayer = getInitializedLacPlayer(player);
-            if (lacPlayer == null || lacPlayer.cache == null) return;
-            lacPlayer.cache.lastGamemodeChange = System.currentTimeMillis();
+            if (lacPlayer == null) return;
+            lacPlayer.cache.lastGamemodeChange = now;
         });
     }
 
@@ -403,10 +413,11 @@ public class LACPlayerListener implements Listener {
     public void lastRespawn(PlayerRespawnEvent event) {
         if (CheckUtil.isExternalNPC(event)) return;
         Player player = event.getPlayer();
+        long now = System.currentTimeMillis();
         Scheduler.entityThread(player, () -> {
             LACPlayer lacPlayer = getInitializedLacPlayer(player);
-            if (lacPlayer == null || lacPlayer.cache == null) return;
-            lacPlayer.cache.lastRespawn = System.currentTimeMillis();
+            if (lacPlayer == null) return;
+            lacPlayer.cache.lastRespawn = now;
         });
     }
 

--- a/src/main/java/me/vekster/lightanticheat/player/LACPlayerListener.java
+++ b/src/main/java/me/vekster/lightanticheat/player/LACPlayerListener.java
@@ -415,7 +415,7 @@ public class LACPlayerListener implements Listener {
     @EventHandler
     public void lastWindCharge(PlayerInteractEvent event) {
         if (CheckUtil.isExternalNPC(event)) return;
-        if (event.getAction() != Action.RIGHT_CLICK_BLOCK)
+        if (event.getAction() != Action.RIGHT_CLICK_BLOCK && event.getAction() != Action.RIGHT_CLICK_AIR)
             return;
         Player player = event.getPlayer();
         ItemStack main = VerPlayer.getItemInMainHand(player);

--- a/src/main/java/me/vekster/lightanticheat/player/cache/PlayerCache.java
+++ b/src/main/java/me/vekster/lightanticheat/player/cache/PlayerCache.java
@@ -61,10 +61,15 @@ public class PlayerCache {
     public Vector vectorOnEntityExplosion;
     public long lastWindCharge;
     public long lastWindChargeReceive;
+    public long lastWindChargeImpact;
+    public long lastEndCrystalImpact;
     public long lastWindBurst;
     public long lastWindBurstNotVanilla;
     public long lastGliding;
     public long lastRiptiding;
+    public long lastRiptideDash;
+    public long lastElytraEquip;
+    public long lastElytraUnequip;
     public long lastFlight;
     public long lastPowderSnowWalk;
     public long lastHitTime;
@@ -93,6 +98,8 @@ public class PlayerCache {
     public BlockCache fromBlockCache;
 
     public boolean alerts = true;
+    public boolean hadElytraEquipped;
+    public boolean hadRiptiding;
 
     public static class History {
         public History(Player player) {

--- a/src/main/java/me/vekster/lightanticheat/player/cache/PlayerCache.java
+++ b/src/main/java/me/vekster/lightanticheat/player/cache/PlayerCache.java
@@ -71,6 +71,7 @@ public class PlayerCache {
     public long lastSwingTime;
     public long lastInsideVehicle;
     public long lastInWater;
+    public long lastClimbingTransition;
 
     public int sneakingTicks;
     public int sprintingTicks;

--- a/src/main/java/me/vekster/lightanticheat/player/cache/entity/CachedEntity.java
+++ b/src/main/java/me/vekster/lightanticheat/player/cache/entity/CachedEntity.java
@@ -1,5 +1,6 @@
 package me.vekster.lightanticheat.player.cache.entity;
 
+import me.vekster.lightanticheat.util.hook.server.folia.FoliaUtil;
 import me.vekster.lightanticheat.version.VerUtil;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
@@ -11,8 +12,16 @@ public class CachedEntity {
     public CachedEntity(Entity entity) {
         uuid = entity.getUniqueId();
         entityType = entity.getType();
-        width = VerUtil.getWidth(entity);
-        height = VerUtil.getHeight(entity);
+
+        double cachedWidth = -1;
+        double cachedHeight = -1;
+        if (!FoliaUtil.isFolia() || FoliaUtil.isOwnedByCurrentRegion(entity)) {
+            cachedWidth = VerUtil.getWidth(entity);
+            cachedHeight = VerUtil.getHeight(entity);
+        }
+
+        width = cachedWidth;
+        height = cachedHeight;
     }
 
     public final UUID uuid;

--- a/src/main/java/me/vekster/lightanticheat/player/cooldown/element/CooldownElement.java
+++ b/src/main/java/me/vekster/lightanticheat/player/cooldown/element/CooldownElement.java
@@ -7,7 +7,7 @@ public class CooldownElement<T> {
         this.time = time;
     }
 
-    public T result;
-    public long time;
+    public volatile T result;
+    public volatile long time;
 
 }

--- a/src/main/java/me/vekster/lightanticheat/util/cooldown/CooldownUtil.java
+++ b/src/main/java/me/vekster/lightanticheat/util/cooldown/CooldownUtil.java
@@ -171,6 +171,10 @@ public class CooldownUtil {
 
         long now = System.currentTimeMillis();
         CooldownElement<Set<CachedEntity>> nearbyElement = cooldown.NEARBY_ENTITIES.get(type);
+        long minRefreshDelay = type == EntityDistance.VERY_NEARBY ? 30 : 40;
+        if (nearbyElement != null && now - nearbyElement.time < minRefreshDelay)
+            return fallback != null ? fallback : ConcurrentHashMap.newKeySet();
+
         if (nearbyElement == null) {
             cooldown.NEARBY_ENTITIES.put(type, new CooldownElement<>(fallback != null ? fallback : ConcurrentHashMap.newKeySet(), now));
         } else {

--- a/src/main/java/me/vekster/lightanticheat/util/cooldown/CooldownUtil.java
+++ b/src/main/java/me/vekster/lightanticheat/util/cooldown/CooldownUtil.java
@@ -12,11 +12,13 @@ import me.vekster.lightanticheat.util.hook.plugin.FloodgateHook;
 import me.vekster.lightanticheat.util.player.entities.NearbyEntitiesUtil;
 import me.vekster.lightanticheat.util.scheduler.Scheduler;
 import me.vekster.lightanticheat.version.VerPlayer;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -108,24 +110,86 @@ public class CooldownUtil {
         long currentTime = System.currentTimeMillis();
         CooldownElement<Set<Entity>> cooldownElement = cooldown.ALL_ENTITIES;
         if (cooldownElement.result == null || currentTime - cooldownElement.time > 444) {
-            cooldownElement.result = NearbyEntitiesUtil.getAllEntitiesAsyncWithoutCache(player);
-            cooldownElement.time = currentTime;
+            if (!FoliaUtil.isFolia()) {
+                if (Bukkit.isPrimaryThread()) {
+                    cooldownElement.result = NearbyEntitiesUtil.getAllEntitiesAsyncWithoutCache(player);
+                    cooldownElement.time = currentTime;
+                    return cooldownElement.result;
+                }
+
+                CompletableFuture<Set<Entity>> future = new CompletableFuture<>();
+                Scheduler.runTask(true, () -> future.complete(NearbyEntitiesUtil.getAllEntitiesAsyncWithoutCache(player)));
+                try {
+                    cooldownElement.result = future.get(250, TimeUnit.MILLISECONDS);
+                    cooldownElement.time = currentTime;
+                    return cooldownElement.result;
+                } catch (InterruptedException | ExecutionException | TimeoutException e) {
+                    return cooldownElement.result != null ? cooldownElement.result : ConcurrentHashMap.newKeySet();
+                }
+            }
+
+            if (FoliaUtil.isOwnedByCurrentRegion(player)) {
+                cooldownElement.result = NearbyEntitiesUtil.getAllEntitiesAsyncWithoutCache(player);
+                cooldownElement.time = currentTime;
+                return cooldownElement.result;
+            }
+
+            FoliaUtil.runTask(player, () -> {
+                cooldownElement.result = NearbyEntitiesUtil.getAllEntitiesAsyncWithoutCache(player);
+                cooldownElement.time = System.currentTimeMillis();
+            });
+            return cooldownElement.result != null ? cooldownElement.result : ConcurrentHashMap.newKeySet();
         }
         return cooldownElement.result;
+    }
+
+    private static Set<CachedEntity> selectNearbyEntitiesSafely(PlayerCooldown cooldown, Player player, Set<Entity> entities,
+                                                                 EntityDistance type, Set<CachedEntity> fallback) {
+        if (!FoliaUtil.isFolia()) {
+            if (Bukkit.isPrimaryThread())
+                return NearbyEntitiesUtil.selectNearbyEntities(player, entities, type);
+
+            CompletableFuture<Set<CachedEntity>> future = new CompletableFuture<>();
+            Scheduler.runTask(true, () -> future.complete(NearbyEntitiesUtil.selectNearbyEntities(player, entities, type)));
+            try {
+                return future.get(250, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException | ExecutionException | TimeoutException e) {
+                return fallback != null ? fallback : ConcurrentHashMap.newKeySet();
+            }
+        }
+
+        if (FoliaUtil.isOwnedByCurrentRegion(player))
+            return NearbyEntitiesUtil.selectNearbyEntities(player, entities, type);
+
+        FoliaUtil.runTask(player, () -> {
+            Set<Entity> freshEntities = NearbyEntitiesUtil.getAllEntitiesAsyncWithoutCache(player);
+            cooldown.ALL_ENTITIES.result = freshEntities;
+            cooldown.ALL_ENTITIES.time = System.currentTimeMillis();
+
+            Set<CachedEntity> freshNearby = NearbyEntitiesUtil.selectNearbyEntities(player, freshEntities, type);
+            CooldownElement<Set<CachedEntity>> nearbyElement = cooldown.NEARBY_ENTITIES.get(type);
+            if (nearbyElement == null) {
+                cooldown.NEARBY_ENTITIES.put(type, new CooldownElement<>(freshNearby, System.currentTimeMillis()));
+            } else {
+                nearbyElement.result = freshNearby;
+                nearbyElement.time = System.currentTimeMillis();
+            }
+        });
+        return fallback != null ? fallback : ConcurrentHashMap.newKeySet();
     }
 
     public static Set<CachedEntity> getNearbyEntitiesAsync(PlayerCooldown cooldown, Player player, EntityDistance type) {
         long currentTime = System.currentTimeMillis();
         CooldownElement<Set<CachedEntity>> cooldownElement = cooldown.NEARBY_ENTITIES.getOrDefault(type, null);
         if (cooldownElement == null) {
-            Set<CachedEntity> entities = NearbyEntitiesUtil.selectNearbyEntities(player, getAllEntitiesAsync(cooldown, player), type);
+            Set<CachedEntity> entities = selectNearbyEntitiesSafely(cooldown, player, getAllEntitiesAsync(cooldown, player), type, null);
             cooldownElement = new CooldownElement<>(entities, currentTime);
             cooldown.NEARBY_ENTITIES.put(type, cooldownElement);
             return cooldownElement.result;
         }
         if (type == EntityDistance.VERY_NEARBY && currentTime - cooldownElement.time > 30 ||
                 type == EntityDistance.NEARBY && currentTime - cooldownElement.time > 40) {
-            cooldownElement.result = NearbyEntitiesUtil.selectNearbyEntities(player, getAllEntitiesAsync(cooldown, player), type);
+            cooldownElement.result = selectNearbyEntitiesSafely(cooldown, player, getAllEntitiesAsync(cooldown, player), type, cooldownElement.result);
             cooldownElement.time = currentTime;
             return cooldownElement.result;
         }

--- a/src/main/java/me/vekster/lightanticheat/util/detection/specific/PassableUtil.java
+++ b/src/main/java/me/vekster/lightanticheat/util/detection/specific/PassableUtil.java
@@ -28,45 +28,52 @@ public class PassableUtil extends GroundUtil {
     }
 
     public static boolean isActuallyPassable(Block block) {
-        String downBlockName = block.getRelative(BlockFace.DOWN).getType().name().toLowerCase();
-        if (downBlockName.endsWith("_wall") || downBlockName.endsWith("_fence") ||
-                downBlockName.endsWith("_fence_gate") || downBlockName.endsWith("shulker_box") ||
-                downBlockName.endsWith("_door"))
+        if (block == null)
             return false;
 
-        if (block.isEmpty())
-            return true;
-        if (!VerUtil.isPassable(block) || block.isLiquid())
+        try {
+            String downBlockName = block.getRelative(BlockFace.DOWN).getType().name().toLowerCase();
+            if (downBlockName.endsWith("_wall") || downBlockName.endsWith("_fence") ||
+                    downBlockName.endsWith("_fence_gate") || downBlockName.endsWith("shulker_box") ||
+                    downBlockName.endsWith("_door"))
+                return false;
+
+            if (block.isEmpty())
+                return true;
+            if (!VerUtil.isPassable(block) || block.isLiquid())
+                return false;
+
+            Material material = block.getType();
+            if (material == Material.STRING || material == Material.LEVER ||
+                    material == Material.TRIPWIRE_HOOK || material == Material.REDSTONE ||
+                    material == Material.ITEM_FRAME || material == VerUtil.material.get("GLOW_ITEM_FRAME") ||
+                    material == Material.PAINTING || material == Material.TORCH ||
+                    material == VerUtil.material.get("REDSTONE_TORCH") || material == VerUtil.material.get("SOUL_TORCH") ||
+                    material == VerUtil.material.get("MANGROVE_PROPAGULE") || material == Material.SUGAR_CANE ||
+                    material == Material.SHORT_GRASS || material == VerUtil.material.get("TALL_GRASS") ||
+                    material == VerUtil.material.get("FERN") || material == VerUtil.material.get("LARGE_FERN"))
+                return true;
+
+            if (FLOWERS.contains(material))
+                return true;
+
+            if (material == Material.SNOW)
+                return VerUtil.getSnowLayers(block) > 1;
+
+            String typeName = material.name().toLowerCase();
+            if (typeName.endsWith("_button") || typeName.endsWith("_pressure_plate") ||
+                    typeName.endsWith("_banner") || typeName.endsWith("_rail") ||
+                    typeName.endsWith("_sign") || typeName.endsWith("_sapling") ||
+                    typeName.endsWith("_carpet") || typeName.endsWith("_coral_fan") ||
+                    typeName.endsWith("_wall_fan") || typeName.endsWith("_hanging_moss") ||
+                    typeName.endsWith("_moss_carpet") || typeName.endsWith("_eyeblossom") ||
+                    typeName.equals("leaf_litter") || typeName.equals("wildflowers") ||
+                    typeName.equals("short_dry_grass") || typeName.equals("tall_dry_grass"))
+                return true;
             return false;
-
-        Material material = block.getType();
-        if (material == Material.STRING || material == Material.LEVER ||
-                material == Material.TRIPWIRE_HOOK || material == Material.REDSTONE ||
-                material == Material.ITEM_FRAME || material == VerUtil.material.get("GLOW_ITEM_FRAME") ||
-                material == Material.PAINTING || material == Material.TORCH ||
-                material == VerUtil.material.get("REDSTONE_TORCH") || material == VerUtil.material.get("SOUL_TORCH") ||
-                material == VerUtil.material.get("MANGROVE_PROPAGULE") || material == Material.SUGAR_CANE ||
-                material == Material.SHORT_GRASS || material == VerUtil.material.get("TALL_GRASS") ||
-                material == VerUtil.material.get("FERN") || material == VerUtil.material.get("LARGE_FERN"))
-            return true;
-
-        if (FLOWERS.contains(material))
-            return true;
-
-        if (material == Material.SNOW)
-            return VerUtil.getSnowLayers(block) > 1;
-
-        String typeName = material.name().toLowerCase();
-        if (typeName.endsWith("_button") || typeName.endsWith("_pressure_plate") ||
-                typeName.endsWith("_banner") || typeName.endsWith("_rail") ||
-                typeName.endsWith("_sign") || typeName.endsWith("_sapling") ||
-                typeName.endsWith("_carpet") || typeName.endsWith("_coral_fan") ||
-                typeName.endsWith("_wall_fan") || typeName.endsWith("_hanging_moss") ||
-                typeName.endsWith("_moss_carpet") || typeName.endsWith("_eyeblossom") ||
-                typeName.equals("leaf_litter") || typeName.equals("wildflowers") ||
-                typeName.equals("short_dry_grass") || typeName.equals("tall_dry_grass"))
-            return true;
-        return false;
+        } catch (RuntimeException exception) {
+            return false;
+        }
     }
 
 }

--- a/src/main/java/me/vekster/lightanticheat/util/detection/specific/PassableUtil.java
+++ b/src/main/java/me/vekster/lightanticheat/util/detection/specific/PassableUtil.java
@@ -46,7 +46,7 @@ public class PassableUtil extends GroundUtil {
                 material == Material.PAINTING || material == Material.TORCH ||
                 material == VerUtil.material.get("REDSTONE_TORCH") || material == VerUtil.material.get("SOUL_TORCH") ||
                 material == VerUtil.material.get("MANGROVE_PROPAGULE") || material == Material.SUGAR_CANE ||
-                material == Material.GRASS || material == VerUtil.material.get("TALL_GRASS") ||
+                material == Material.SHORT_GRASS || material == VerUtil.material.get("TALL_GRASS") ||
                 material == VerUtil.material.get("FERN") || material == VerUtil.material.get("LARGE_FERN"))
             return true;
 

--- a/src/main/java/me/vekster/lightanticheat/util/detection/specific/PassableUtil.java
+++ b/src/main/java/me/vekster/lightanticheat/util/detection/specific/PassableUtil.java
@@ -59,7 +59,12 @@ public class PassableUtil extends GroundUtil {
         String typeName = material.name().toLowerCase();
         if (typeName.endsWith("_button") || typeName.endsWith("_pressure_plate") ||
                 typeName.endsWith("_banner") || typeName.endsWith("_rail") ||
-                typeName.endsWith("_sign") || typeName.endsWith("_sapling"))
+                typeName.endsWith("_sign") || typeName.endsWith("_sapling") ||
+                typeName.endsWith("_carpet") || typeName.endsWith("_coral_fan") ||
+                typeName.endsWith("_wall_fan") || typeName.endsWith("_hanging_moss") ||
+                typeName.endsWith("_moss_carpet") || typeName.endsWith("_eyeblossom") ||
+                typeName.equals("leaf_litter") || typeName.equals("wildflowers") ||
+                typeName.equals("short_dry_grass") || typeName.equals("tall_dry_grass"))
             return true;
         return false;
     }

--- a/src/main/java/me/vekster/lightanticheat/util/hook/plugin/simplehook/McMMOHook.java
+++ b/src/main/java/me/vekster/lightanticheat/util/hook/plugin/simplehook/McMMOHook.java
@@ -1,12 +1,16 @@
 package me.vekster.lightanticheat.util.hook.plugin.simplehook;
 
 import me.vekster.lightanticheat.util.hook.plugin.HookUtil;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
 
 public class McMMOHook extends HookUtil {
 
@@ -19,52 +23,124 @@ public class McMMOHook extends HookUtil {
             "greenTerraEnabled"
     };
 
+    private static volatile boolean abilityApiInitialized = false;
+    private static volatile Method[] blockBreakAbilityMethods = null;
+
+    /**
+     * Prefer mcMMO runtime API for active abilities when available.
+     * Falls back to the legacy material-based check when the API is unavailable or cannot be queried.
+     */
     public static boolean isPrevented(Player player, Block block) {
         if (!isPlugin(PLUGIN_NAME))
             return false;
 
         Boolean activeAbility = isBlockBreakAbilityActive(player);
-        if (Boolean.TRUE.equals(activeAbility))
-            return true;
+        if (activeAbility != null)
+            return activeAbility;
 
+        // API unavailable / unknown -> legacy fallback
         return isPrevented(block.getType());
     }
 
+    /**
+     * Legacy fallback behavior (kept for compatibility).
+     */
     public static boolean isPrevented(Material material) {
         if (!isPlugin(PLUGIN_NAME))
             return false;
+
         String name = material.name();
-        if (name.endsWith("_LOG") || name.endsWith("_LEAVES"))
-            return true;
-        return false;
+        return name.endsWith("_LOG") || name.endsWith("_LEAVES");
     }
 
+    /**
+     * @return TRUE if an mcMMO block-break ability is active;
+     * FALSE if API is available and reports no active ability;
+     * NULL if API is unavailable or could not be queried reliably.
+     */
     private static Boolean isBlockBreakAbilityActive(Player player) {
-        Class<?> abilityApiClass;
+        Method[] methods = getBlockBreakAbilityMethods();
+        if (methods == null || methods.length == 0)
+            return null;
+
+        boolean hadUnknown = false;
+        for (Method method : methods) {
+            Boolean active = invokeAbilityMethod(method, player);
+            if (Boolean.TRUE.equals(active))
+                return true;
+            if (active == null)
+                hadUnknown = true;
+        }
+
+        // If any call failed/was unknown, be safe and fall back to legacy checks.
+        return hadUnknown ? null : false;
+    }
+
+    private static Method[] getBlockBreakAbilityMethods() {
+        if (abilityApiInitialized)
+            return blockBreakAbilityMethods;
+
+        synchronized (McMMOHook.class) {
+            if (abilityApiInitialized)
+                return blockBreakAbilityMethods;
+
+            Class<?> abilityApiClass = loadAbilityApiClass();
+            if (abilityApiClass == null) {
+                abilityApiInitialized = true;
+                blockBreakAbilityMethods = null;
+                return null;
+            }
+
+            List<Method> methods = new ArrayList<>();
+            for (String methodName : BLOCK_BREAK_ABILITY_METHODS) {
+                try {
+                    Method method = abilityApiClass.getMethod(methodName, Player.class);
+                    methods.add(method);
+                } catch (NoSuchMethodException ignored) {
+                    // method not present in this mcMMO version
+                }
+            }
+
+            blockBreakAbilityMethods = methods.isEmpty() ? null : methods.toArray(new Method[0]);
+            abilityApiInitialized = true;
+            return blockBreakAbilityMethods;
+        }
+    }
+
+    private static Class<?> loadAbilityApiClass() {
+        // Attempt 1: current classloader
         try {
-            abilityApiClass = Class.forName(ABILITY_API_CLASS);
-        } catch (ClassNotFoundException exception) {
+            return Class.forName(ABILITY_API_CLASS);
+        } catch (ClassNotFoundException ignored) {
+        } catch (LinkageError ignored) {
             return null;
         }
 
-        for (String methodName : BLOCK_BREAK_ABILITY_METHODS) {
-            Boolean active = invokeAbilityMethod(abilityApiClass, methodName, player);
-            if (Boolean.TRUE.equals(active))
-                return true;
+        // Attempt 2: mcMMO plugin classloader (more robust on some servers)
+        try {
+            Plugin plugin = Bukkit.getPluginManager().getPlugin(PLUGIN_NAME);
+            if (plugin == null)
+                return null;
+            ClassLoader classLoader = plugin.getClass().getClassLoader();
+            return classLoader.loadClass(ABILITY_API_CLASS);
+        } catch (ClassNotFoundException ignored) {
+            return null;
+        } catch (LinkageError ignored) {
+            return null;
         }
-        return false;
     }
 
-    private static Boolean invokeAbilityMethod(Class<?> abilityApiClass, String methodName, Player player) {
+    private static Boolean invokeAbilityMethod(Method method, Player player) {
         try {
-            Method method = abilityApiClass.getMethod(methodName, Player.class);
             Object result = method.invoke(null, player);
             if (result instanceof Boolean)
                 return (Boolean) result;
-        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException exception) {
+            return null;
+        } catch (IllegalAccessException | InvocationTargetException | IllegalArgumentException ignored) {
+            return null;
+        } catch (LinkageError ignored) {
             return null;
         }
-        return false;
     }
 
 }

--- a/src/main/java/me/vekster/lightanticheat/util/hook/plugin/simplehook/McMMOHook.java
+++ b/src/main/java/me/vekster/lightanticheat/util/hook/plugin/simplehook/McMMOHook.java
@@ -2,10 +2,33 @@ package me.vekster.lightanticheat.util.hook.plugin.simplehook;
 
 import me.vekster.lightanticheat.util.hook.plugin.HookUtil;
 import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 public class McMMOHook extends HookUtil {
 
     private static final String PLUGIN_NAME = "mcMMO";
+    private static final String ABILITY_API_CLASS = "com.gmail.nossr50.api.AbilityAPI";
+    private static final String[] BLOCK_BREAK_ABILITY_METHODS = {
+            "treeFellerEnabled",
+            "superBreakerEnabled",
+            "gigaDrillBreakerEnabled",
+            "greenTerraEnabled"
+    };
+
+    public static boolean isPrevented(Player player, Block block) {
+        if (!isPlugin(PLUGIN_NAME))
+            return false;
+
+        Boolean activeAbility = isBlockBreakAbilityActive(player);
+        if (Boolean.TRUE.equals(activeAbility))
+            return true;
+
+        return isPrevented(block.getType());
+    }
 
     public static boolean isPrevented(Material material) {
         if (!isPlugin(PLUGIN_NAME))
@@ -13,6 +36,34 @@ public class McMMOHook extends HookUtil {
         String name = material.name();
         if (name.endsWith("_LOG") || name.endsWith("_LEAVES"))
             return true;
+        return false;
+    }
+
+    private static Boolean isBlockBreakAbilityActive(Player player) {
+        Class<?> abilityApiClass;
+        try {
+            abilityApiClass = Class.forName(ABILITY_API_CLASS);
+        } catch (ClassNotFoundException exception) {
+            return null;
+        }
+
+        for (String methodName : BLOCK_BREAK_ABILITY_METHODS) {
+            Boolean active = invokeAbilityMethod(abilityApiClass, methodName, player);
+            if (Boolean.TRUE.equals(active))
+                return true;
+        }
+        return false;
+    }
+
+    private static Boolean invokeAbilityMethod(Class<?> abilityApiClass, String methodName, Player player) {
+        try {
+            Method method = abilityApiClass.getMethod(methodName, Player.class);
+            Object result = method.invoke(null, player);
+            if (result instanceof Boolean)
+                return (Boolean) result;
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException exception) {
+            return null;
+        }
         return false;
     }
 

--- a/src/main/java/me/vekster/lightanticheat/util/player/connectionstability/ConnectionStabilityListener.java
+++ b/src/main/java/me/vekster/lightanticheat/util/player/connectionstability/ConnectionStabilityListener.java
@@ -7,17 +7,23 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class ConnectionStabilityListener implements Listener {
 
-    private static final Map<UUID, List<Integer>> PLAYERS = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<UUID, List<Integer>> PLAYERS = new ConcurrentHashMap<>();
 
     @EventHandler
     public void onJoin(PlayerJoinEvent event) {
-        PLAYERS.put(event.getPlayer().getUniqueId(), Collections.synchronizedList(new ArrayList<>(Arrays.asList(0, 0, 0, 0))));
+        PLAYERS.put(event.getPlayer().getUniqueId(), createHistoryWindow());
+    }
+
+    @EventHandler
+    public void onQuit(PlayerQuitEvent event) {
+        PLAYERS.remove(event.getPlayer().getUniqueId());
     }
 
     @EventHandler
@@ -39,7 +45,7 @@ public class ConnectionStabilityListener implements Listener {
                 onlinePlayers.add(player.getUniqueId());
 
             for (UUID onlinePlayer : onlinePlayers)
-                PLAYERS.putIfAbsent(onlinePlayer, Collections.synchronizedList(new ArrayList<>(Arrays.asList(0, 0, 0, 0))));
+                PLAYERS.putIfAbsent(onlinePlayer, createHistoryWindow());
 
             PLAYERS.entrySet().removeIf(entry -> {
                 if (!onlinePlayers.contains(entry.getKey()))
@@ -61,7 +67,12 @@ public class ConnectionStabilityListener implements Listener {
 
         PLAYERS.keySet().removeIf(uuid -> !onlinePlayers.contains(uuid));
         for (UUID onlinePlayer : onlinePlayers)
-            PLAYERS.put(onlinePlayer, Collections.synchronizedList(new ArrayList<>(Arrays.asList(0, 0, 0, 0))));
+            PLAYERS.put(onlinePlayer, createHistoryWindow());
+    }
+
+
+    private static List<Integer> createHistoryWindow() {
+        return Collections.synchronizedList(new ArrayList<>(Arrays.asList(0, 0, 0, 0)));
     }
 
     public static ConnectionStability getConnectionStability(Player player) {

--- a/src/main/java/me/vekster/lightanticheat/util/player/connectionstability/ConnectionStabilityListener.java
+++ b/src/main/java/me/vekster/lightanticheat/util/player/connectionstability/ConnectionStabilityListener.java
@@ -52,7 +52,10 @@ public class ConnectionStabilityListener implements Listener {
     }
 
     public static ConnectionStability getConnectionStability(Player player) {
-        UUID uuid = player.getUniqueId();
+        return getConnectionStability(player.getUniqueId());
+    }
+
+    public static ConnectionStability getConnectionStability(UUID uuid) {
         if (!PLAYERS.containsKey(uuid))
             return ConnectionStability.HIGH;
         List<Integer> list = PLAYERS.get(uuid);

--- a/src/main/java/me/vekster/lightanticheat/util/player/connectionstability/ConnectionStabilityListener.java
+++ b/src/main/java/me/vekster/lightanticheat/util/player/connectionstability/ConnectionStabilityListener.java
@@ -38,6 +38,9 @@ public class ConnectionStabilityListener implements Listener {
             for (Player player : Bukkit.getOnlinePlayers())
                 onlinePlayers.add(player.getUniqueId());
 
+            for (UUID onlinePlayer : onlinePlayers)
+                PLAYERS.putIfAbsent(onlinePlayer, Collections.synchronizedList(new ArrayList<>(Arrays.asList(0, 0, 0, 0))));
+
             PLAYERS.entrySet().removeIf(entry -> {
                 if (!onlinePlayers.contains(entry.getKey()))
                     return true;
@@ -52,9 +55,13 @@ public class ConnectionStabilityListener implements Listener {
     }
 
     public static void loadConnectionCalculatorOnReload() {
-        for (Player player : Bukkit.getOnlinePlayers()) {
-            PLAYERS.put(player.getUniqueId(), Collections.synchronizedList(new ArrayList<>(Arrays.asList(0, 0, 0, 0))));
-        }
+        Set<UUID> onlinePlayers = new HashSet<>();
+        for (Player player : Bukkit.getOnlinePlayers())
+            onlinePlayers.add(player.getUniqueId());
+
+        PLAYERS.keySet().removeIf(uuid -> !onlinePlayers.contains(uuid));
+        for (UUID onlinePlayer : onlinePlayers)
+            PLAYERS.put(onlinePlayer, Collections.synchronizedList(new ArrayList<>(Arrays.asList(0, 0, 0, 0))));
     }
 
     public static ConnectionStability getConnectionStability(Player player) {

--- a/src/main/java/me/vekster/lightanticheat/util/player/connectionstability/ConnectionStabilityListener.java
+++ b/src/main/java/me/vekster/lightanticheat/util/player/connectionstability/ConnectionStabilityListener.java
@@ -67,12 +67,12 @@ public class ConnectionStabilityListener implements Listener {
 
         PLAYERS.keySet().removeIf(uuid -> !onlinePlayers.contains(uuid));
         for (UUID onlinePlayer : onlinePlayers)
-            PLAYERS.put(onlinePlayer, createHistoryWindow());
+            PLAYERS.putIfAbsent(onlinePlayer, createHistoryWindow());
     }
 
 
     private static List<Integer> createHistoryWindow() {
-        return Collections.synchronizedList(new ArrayList<>(Arrays.asList(0, 0, 0, 0)));
+        return new ArrayList<>(Arrays.asList(0, 0, 0, 0));
     }
 
     public static ConnectionStability getConnectionStability(Player player) {

--- a/src/main/java/me/vekster/lightanticheat/util/player/connectionstability/ConnectionStabilityListener.java
+++ b/src/main/java/me/vekster/lightanticheat/util/player/connectionstability/ConnectionStabilityListener.java
@@ -33,6 +33,8 @@ public class ConnectionStabilityListener implements Listener {
         if (list == null)
             return;
         synchronized (list) {
+            if (list.isEmpty())
+                list.addAll(Arrays.asList(0, 0, 0, 0));
             int lastIndex = list.size() - 1;
             list.set(lastIndex, list.get(lastIndex) + 1);
         }
@@ -52,8 +54,12 @@ public class ConnectionStabilityListener implements Listener {
                     return true;
                 List<Integer> list = entry.getValue();
                 synchronized (list) {
-                    list.add(0);
-                    list.remove(0);
+                    if (list.isEmpty()) {
+                        list.addAll(Arrays.asList(0, 0, 0, 0));
+                    } else {
+                        list.add(0);
+                        list.remove(0);
+                    }
                 }
                 return false;
             });

--- a/src/main/java/me/vekster/lightanticheat/util/player/connectionstability/ConnectionStabilityListener.java
+++ b/src/main/java/me/vekster/lightanticheat/util/player/connectionstability/ConnectionStabilityListener.java
@@ -16,6 +16,8 @@ public class ConnectionStabilityListener implements Listener {
 
     private static final ConcurrentHashMap<UUID, List<Integer>> PLAYERS = new ConcurrentHashMap<>();
     private static final long TARGET_WINDOW_MILLIS = 2000L;
+    private static final long MIN_ELAPSED_MILLIS = 500L;
+    private static final long MAX_ELAPSED_MILLIS = 15_000L;
     private static volatile long lastRotationTime = System.currentTimeMillis();
 
     @EventHandler
@@ -43,9 +45,10 @@ public class ConnectionStabilityListener implements Listener {
     }
 
     public static void loadConnectionCalculator() {
+        lastRotationTime = System.currentTimeMillis();
         Scheduler.runTaskTimer(() -> {
             long currentTime = System.currentTimeMillis();
-            long elapsedTime = Math.max(1L, currentTime - lastRotationTime);
+            long elapsedTime = clampElapsedTime(currentTime - lastRotationTime);
             lastRotationTime = currentTime;
 
             Set<UUID> onlinePlayers = new HashSet<>();
@@ -89,6 +92,12 @@ public class ConnectionStabilityListener implements Listener {
         return new ArrayList<>(Arrays.asList(0, 0, 0, 0));
     }
 
+
+    private static long clampElapsedTime(long elapsedTime) {
+        if (elapsedTime <= 0)
+            return MIN_ELAPSED_MILLIS;
+        return Math.min(MAX_ELAPSED_MILLIS, Math.max(MIN_ELAPSED_MILLIS, elapsedTime));
+    }
 
     private static int normalizeToTargetWindow(int value, long elapsedTime) {
         if (elapsedTime <= 0)

--- a/src/main/java/me/vekster/lightanticheat/util/player/entities/NearbyEntitiesUtil.java
+++ b/src/main/java/me/vekster/lightanticheat/util/player/entities/NearbyEntitiesUtil.java
@@ -20,6 +20,9 @@ import java.util.concurrent.*;
 public class NearbyEntitiesUtil {
 
     public static Set<Entity> getAllEntitiesAsyncWithoutCache(Player player) {
+        if (FoliaUtil.isFolia() && !FoliaUtil.isOwnedByCurrentRegion(player))
+            return ConcurrentHashMap.newKeySet();
+
         if ((VerIdentifier.getVersion().isOlderOrEqualsTo(LACVersion.V1_8) || !PaperUtil.isPaper()) && !FoliaUtil.isFolia()) {
             if (Bukkit.isPrimaryThread()) {
                 try {
@@ -82,6 +85,9 @@ public class NearbyEntitiesUtil {
 
     public static Set<CachedEntity> selectNearbyEntities(Player player, Set<Entity> entities, EntityDistance type) {
         Set<CachedEntity> result = ConcurrentHashMap.newKeySet();
+        if (FoliaUtil.isFolia() && !FoliaUtil.isOwnedByCurrentRegion(player))
+            return result;
+
         Location location = player.getLocation();
         double x = location.getX();
         double y = location.getY();

--- a/src/main/java/me/vekster/lightanticheat/util/scheduler/Scheduler.java
+++ b/src/main/java/me/vekster/lightanticheat/util/scheduler/Scheduler.java
@@ -4,6 +4,7 @@ import me.vekster.lightanticheat.util.hook.server.folia.FoliaUtil;
 import me.vekster.lightanticheat.util.scheduler.gamescheduler.BukkitScheduler;
 import me.vekster.lightanticheat.util.scheduler.gamescheduler.FoliaScheduler;
 import me.vekster.lightanticheat.util.scheduler.gamescheduler.GameScheduler;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 
@@ -66,16 +67,30 @@ public class Scheduler {
 
     @SuppressWarnings("unchecked")
     public static <T> T entityThread(Player player, boolean force, T defaultValue, Supplier<Object> supplier) {
+        if (player == null || supplier == null)
+            return defaultValue;
+
+        if (!FoliaUtil.isFolia() || Bukkit.isPrimaryThread() || FoliaUtil.isOwnedByCurrentRegion(player)) {
+            Object result = supplier.get();
+            return result != null ? (T) result : defaultValue;
+        }
+
+        if (isTickThread())
+            return defaultValue;
+
         CompletableFuture<Object> future = new CompletableFuture<>();
-        entityThread(player, force, () -> {
-            future.complete(supplier.get());
-        });
+        entityThread(player, force, () -> future.complete(supplier.get()));
         try {
             Object result = future.get(500, TimeUnit.MILLISECONDS);
             return result != null ? (T) result : defaultValue;
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             return defaultValue;
         }
+    }
+
+    private static boolean isTickThread() {
+        String name = Thread.currentThread().getName();
+        return name != null && (name.contains("Region Scheduler Thread") || name.equals("Server thread"));
     }
 
     public static void schedule(TimerTask task, long delayInMs) {

--- a/src/main/java/me/vekster/lightanticheat/util/scheduler/Scheduler.java
+++ b/src/main/java/me/vekster/lightanticheat/util/scheduler/Scheduler.java
@@ -41,6 +41,10 @@ public class Scheduler {
         SCHEDULER.runTaskLater(entity, task, delayInTicks);
     }
 
+    public static void runTaskLater(Player player, Runnable task) {
+        SCHEDULER.runTaskLater(player, task, 1);
+    }
+
     public static void runTaskLaterAsynchronously(Runnable task, long delayInTicks) {
         SCHEDULER.runTaskLaterAsynchronously(task, delayInTicks);
     }

--- a/src/main/java/me/vekster/lightanticheat/util/scheduler/gamescheduler/FoliaScheduler.java
+++ b/src/main/java/me/vekster/lightanticheat/util/scheduler/gamescheduler/FoliaScheduler.java
@@ -57,8 +57,10 @@ public class FoliaScheduler implements GameScheduler {
 
     @Override
     public void entityThread(Player player, boolean force, Runnable task) {
-        if (!force)
+        if (!force) {
             entityThread(player, task);
+            return;
+        }
         FoliaUtil.runTask(player, task);
     }
 

--- a/src/main/java/me/vekster/lightanticheat/version/VerPlayer.java
+++ b/src/main/java/me/vekster/lightanticheat/version/VerPlayer.java
@@ -2,13 +2,16 @@ package me.vekster.lightanticheat.version;
 
 import me.vekster.lightanticheat.player.LACPlayer;
 import me.vekster.lightanticheat.util.annotation.SecureAsync;
+import me.vekster.lightanticheat.util.async.AsyncUtil;
 import me.vekster.lightanticheat.util.cooldown.CooldownUtil;
+import me.vekster.lightanticheat.util.hook.server.folia.FoliaUtil;
 import me.vekster.lightanticheat.util.reflection.ReflectionException;
 import me.vekster.lightanticheat.util.reflection.ReflectionUtil;
 import me.vekster.lightanticheat.version.identifier.LACVersion;
 import me.vekster.lightanticheat.version.identifier.VerIdentifier;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.EquipmentSlot;
@@ -157,12 +160,28 @@ public class VerPlayer {
 
     @SecureAsync
     public static boolean isClimbing(Player player) {
-        return VerUtil.multiVersion.isClimbing(player);
+        if (!isPlayerStableForRegion(player))
+            return false;
+        try {
+            return VerUtil.multiVersion.isClimbing(player);
+        } catch (IllegalStateException ignored) {
+            return false;
+        }
     }
 
     @SecureAsync
     public boolean isClimbing() {
-        return VerUtil.multiVersion.isClimbing(PLAYER);
+        return isClimbing(PLAYER);
+    }
+
+    private static boolean isPlayerStableForRegion(Player player) {
+        if (!FoliaUtil.isStable(player))
+            return false;
+        World asyncWorld = AsyncUtil.getWorld(player);
+        World playerWorld = player.getWorld();
+        if (asyncWorld == null || playerWorld == null)
+            return false;
+        return asyncWorld.getUID().equals(playerWorld.getUID());
     }
 
     @SecureAsync

--- a/src/main/java/me/vekster/lightanticheat/version/VerPlayer.java
+++ b/src/main/java/me/vekster/lightanticheat/version/VerPlayer.java
@@ -160,9 +160,9 @@ public class VerPlayer {
 
     @SecureAsync
     public static boolean isClimbing(Player player) {
-        if (!isPlayerStableForRegion(player))
-            return false;
         try {
+            if (!isPlayerStableForRegion(player))
+                return false;
             return VerUtil.multiVersion.isClimbing(player);
         } catch (IllegalStateException ignored) {
             return false;
@@ -175,13 +175,17 @@ public class VerPlayer {
     }
 
     private static boolean isPlayerStableForRegion(Player player) {
-        if (!FoliaUtil.isStable(player))
+        try {
+            if (!FoliaUtil.isStable(player))
+                return false;
+            World asyncWorld = AsyncUtil.getWorld(player);
+            World playerWorld = player.getWorld();
+            if (asyncWorld == null || playerWorld == null)
+                return false;
+            return asyncWorld.getUID().equals(playerWorld.getUID());
+        } catch (IllegalStateException ignored) {
             return false;
-        World asyncWorld = AsyncUtil.getWorld(player);
-        World playerWorld = player.getWorld();
-        if (asyncWorld == null || playerWorld == null)
-            return false;
-        return asyncWorld.getUID().equals(playerWorld.getUID());
+        }
     }
 
     @SecureAsync

--- a/src/main/java/me/vekster/lightanticheat/version/VerPlayer.java
+++ b/src/main/java/me/vekster/lightanticheat/version/VerPlayer.java
@@ -1,11 +1,8 @@
 package me.vekster.lightanticheat.version;
 
-import me.vekster.lightanticheat.Main;
 import me.vekster.lightanticheat.player.LACPlayer;
 import me.vekster.lightanticheat.util.annotation.SecureAsync;
 import me.vekster.lightanticheat.util.cooldown.CooldownUtil;
-import me.vekster.lightanticheat.util.logger.LogType;
-import me.vekster.lightanticheat.util.logger.Logger;
 import me.vekster.lightanticheat.util.reflection.ReflectionException;
 import me.vekster.lightanticheat.util.reflection.ReflectionUtil;
 import me.vekster.lightanticheat.version.identifier.LACVersion;
@@ -22,22 +19,16 @@ import org.jetbrains.annotations.Nullable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class VerPlayer {
 
     private static final Map<String, Boolean> CACHE = new HashMap<>();
     private static final Map<String, Boolean> ASYNC_CACHE = new ConcurrentHashMap<>();
-    private static Class<?> craftPlayerClass;
     private final Player PLAYER;
 
-    static {
-        try {
-            craftPlayerClass = ReflectionUtil.classForName("org.bukkit.craftbukkit.$version.entity.CraftPlayer");
-        } catch (ReflectionException e) {
-            Logger.logConsole(LogType.ERROR, "(" + Main.getInstance().getName() + ") CraftPlayer class is not found!");
-        }
-    }
+
 
     public VerPlayer(Player player) {
         this.PLAYER = player;
@@ -60,20 +51,11 @@ public class VerPlayer {
                 Object value = ReflectionUtil.runDeclaredMethod(player, methodName);
                 if (value instanceof Integer)
                     return (int) value;
-                return 250;
             }
-
-            if (craftPlayerClass == null) return 0;
-            Object craftPlayer = craftPlayerClass.cast(player);
-            Object entityPlayer = ReflectionUtil.runDeclaredMethod(craftPlayer, "getHandle");
-            if (entityPlayer == null) return 0;
-            Object result = ReflectionUtil.getDeclaredField(entityPlayer, "ping");
-            if (result instanceof Integer)
-                return (int) result;
-        } catch (ReflectionException e) {
+            return player.spigot().getPing();
+        } catch (Throwable throwable) {
             return 250;
         }
-        return 250;
     }
 
     public static int getPing(Player player) {
@@ -92,6 +74,15 @@ public class VerPlayer {
     @SecureAsync
     public int getPing(boolean async) {
         return CooldownUtil.getPing(LACPlayer.getLacPlayer(PLAYER).cooldown, PLAYER, async);
+    }
+
+
+    public static UUID getUniqueId(Player player) {
+        return player.getUniqueId();
+    }
+
+    public UUID getUniqueId() {
+        return PLAYER.getUniqueId();
     }
 
     @SecureAsync

--- a/src/main/java/me/vekster/lightanticheat/version/VerPlayer.java
+++ b/src/main/java/me/vekster/lightanticheat/version/VerPlayer.java
@@ -52,10 +52,19 @@ public class VerPlayer {
                 if (value instanceof Integer)
                     return (int) value;
             }
-            return player.spigot().getPing();
-        } catch (Throwable throwable) {
+
+            Class<?> craftPlayerClass = ReflectionUtil.classForName("org.bukkit.craftbukkit.$version.entity.CraftPlayer");
+            Object craftPlayer = craftPlayerClass.cast(player);
+            Object entityPlayer = ReflectionUtil.runDeclaredMethod(craftPlayer, "getHandle");
+            if (entityPlayer == null)
+                return 250;
+            Object result = ReflectionUtil.getDeclaredField(entityPlayer, "ping");
+            if (result instanceof Integer)
+                return (int) result;
+        } catch (ReflectionException | RuntimeException | LinkageError ignored) {
             return 250;
         }
+        return 250;
     }
 
     public static int getPing(Player player) {

--- a/src/main/java/me/vekster/lightanticheat/version/VerUtil.java
+++ b/src/main/java/me/vekster/lightanticheat/version/VerUtil.java
@@ -26,6 +26,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 public class VerUtil {
     protected static MultiVersion multiVersion = null;
@@ -53,6 +54,11 @@ public class VerUtil {
         }
     }
 
+
+
+    public static UUID getPlayerUniqueId(Player player) {
+        return player.getUniqueId();
+    }
 
     private static <T> void alias(Map<String, T> values, String canonicalKey, String... aliases) {
         T value = values.get(canonicalKey.toLowerCase());

--- a/src/main/java/me/vekster/lightanticheat/version/VerUtil.java
+++ b/src/main/java/me/vekster/lightanticheat/version/VerUtil.java
@@ -53,6 +53,48 @@ public class VerUtil {
         }
     }
 
+
+    private static <T> void alias(Map<String, T> values, String canonicalKey, String... aliases) {
+        T value = values.get(canonicalKey.toLowerCase());
+        if (value == null)
+            return;
+        for (String alias : aliases) {
+            if (alias == null)
+                continue;
+            values.putIfAbsent(alias.toLowerCase(), value);
+        }
+    }
+
+    private static void registerMaterialAliases(Map<String, Material> materials) {
+        alias(materials, "trial_spawner", "ominous_trial_spawner");
+        alias(materials, "vault", "ominous_vault");
+        alias(materials, "trial_key", "ominous_trial_key");
+        alias(materials, "eyeblossom", "open_eyeblossom", "closed_eyeblossom");
+        alias(materials, "moss_carpet", "pale_moss_carpet");
+        alias(materials, "hanging_moss", "pale_hanging_moss");
+        alias(materials, "chain", "iron_chain", "copper_chain");
+        alias(materials, "iron_chain", "chain", "copper_chain");
+        alias(materials, "music_disc_creator_music_box", "music_disc_creator");
+    }
+
+    private static void registerEntityAliases(Map<String, EntityType> entityTypes) {
+        alias(entityTypes, "bogged", "parched");
+        alias(entityTypes, "husk", "camel_husk");
+        alias(entityTypes, "ghast", "happy_ghast", "ghastling");
+        alias(entityTypes, "drowned", "zombie_nautilus", "coral_zombie_nautilus");
+        alias(entityTypes, "iron_golem", "copper_golem");
+        alias(entityTypes, "breeze", "nautilus");
+    }
+
+    private static void registerPotionAliases(Map<String, PotionEffectType> potions) {
+        alias(potions, "bad_omen", "raid_omen", "trial_omen");
+        alias(potions, "wind_charged", "wind_charge");
+    }
+
+    private static void registerEnchantmentAliases(Map<String, Enchantment> enchantments) {
+        alias(enchantments, "breach", "lunge");
+    }
+
     static {
         LACVersion lacVersion = VerIdentifier.getVersion();
         switch (lacVersion) {
@@ -365,6 +407,7 @@ public class VerUtil {
             if (material == null) continue;
             materials.put(material.name().toLowerCase(), material);
         }
+        registerMaterialAliases(materials);
         VerUtil.material = new VerEnumValues<>(materials, Material.MAP);
 
         Map<String, Enchantment> enchantments = new HashMap<>();
@@ -374,6 +417,7 @@ public class VerUtil {
             if (key == null) continue;
             enchantments.put(key.toLowerCase(), enchantment);
         }
+        registerEnchantmentAliases(enchantments);
         VerUtil.enchantment = new VerEnumValues<>(enchantments, Enchantment.LUCK);
         Scheduler.runTask(false, () -> {
             Map<String, Enchantment> newerEnchantments = new HashMap<>();
@@ -383,6 +427,7 @@ public class VerUtil {
                 if (key == null) continue;
                 newerEnchantments.put(key.toLowerCase(), enchantment);
             }
+            registerEnchantmentAliases(newerEnchantments);
             VerUtil.enchantment = new VerEnumValues<>(newerEnchantments, Enchantment.LUCK);
         });
 
@@ -391,6 +436,7 @@ public class VerUtil {
             if (entityType == null) continue;
             entityTypes.put(entityType.name().toLowerCase(), entityType);
         }
+        registerEntityAliases(entityTypes);
         VerUtil.entityTypes = new VerEnumValues<>(entityTypes, EntityType.UNKNOWN);
 
         Map<String, PotionEffectType> potions = new HashMap<>();
@@ -398,6 +444,7 @@ public class VerUtil {
             if (potionEffectType == null) continue;
             potions.put(potionEffectType.getName().toLowerCase(), potionEffectType);
         }
+        registerPotionAliases(potions);
         VerUtil.potions = new VerEnumValues<>(potions, PotionEffectType.NIGHT_VISION);
         Scheduler.runTask(false, () -> {
             Map<String, PotionEffectType> newerPotions = new HashMap<>();
@@ -405,6 +452,7 @@ public class VerUtil {
                 if (potionEffectType == null) continue;
                 newerPotions.put(potionEffectType.getName().toLowerCase(), potionEffectType);
             }
+            registerPotionAliases(newerPotions);
             VerUtil.potions = new VerEnumValues<>(newerPotions, PotionEffectType.NIGHT_VISION);
         });
     }

--- a/src/main/java/me/vekster/lightanticheat/version/VerUtil.java
+++ b/src/main/java/me/vekster/lightanticheat/version/VerUtil.java
@@ -416,14 +416,18 @@ public class VerUtil {
         Map<String, PotionEffectType> potions = new HashMap<>();
         for (PotionEffectType potionEffectType : PotionEffectType.values()) {
             if (potionEffectType == null) continue;
-            potions.put(potionEffectType.getName().toLowerCase(), potionEffectType);
+            String potionName = potionEffectType.getName();
+            if (potionName == null) continue;
+            potions.put(potionName.toLowerCase(), potionEffectType);
         }
         VerUtil.potions = new VerEnumValues<>(potions, PotionEffectType.NIGHT_VISION);
         Scheduler.runTask(false, () -> {
             Map<String, PotionEffectType> newerPotions = new HashMap<>();
             for (PotionEffectType potionEffectType : PotionEffectType.values()) {
                 if (potionEffectType == null) continue;
-                newerPotions.put(potionEffectType.getName().toLowerCase(), potionEffectType);
+                String potionName = potionEffectType.getName();
+                if (potionName == null) continue;
+                newerPotions.put(potionName.toLowerCase(), potionEffectType);
             }
             VerUtil.potions = new VerEnumValues<>(newerPotions, PotionEffectType.NIGHT_VISION);
         });

--- a/src/main/java/me/vekster/lightanticheat/version/VerUtil.java
+++ b/src/main/java/me/vekster/lightanticheat/version/VerUtil.java
@@ -333,6 +333,7 @@ public class VerUtil {
                 };
                 break;
             case V1_20:
+            case V1_21:
                 multiVersion = new V1_20(Main.getInstance()) {
                     @Override
                     public void onBlockPlace(BlockPlaceEvent event) {

--- a/src/main/java/me/vekster/lightanticheat/version/VerUtil.java
+++ b/src/main/java/me/vekster/lightanticheat/version/VerUtil.java
@@ -66,33 +66,10 @@ public class VerUtil {
     }
 
     private static void registerMaterialAliases(Map<String, Material> materials) {
-        alias(materials, "trial_spawner", "ominous_trial_spawner");
-        alias(materials, "vault", "ominous_vault");
-        alias(materials, "trial_key", "ominous_trial_key");
+        // Keep only low-risk naming aliases for near-equivalent flora variants.
         alias(materials, "eyeblossom", "open_eyeblossom", "closed_eyeblossom");
         alias(materials, "moss_carpet", "pale_moss_carpet");
         alias(materials, "hanging_moss", "pale_hanging_moss");
-        alias(materials, "chain", "iron_chain", "copper_chain");
-        alias(materials, "iron_chain", "chain", "copper_chain");
-        alias(materials, "music_disc_creator_music_box", "music_disc_creator");
-    }
-
-    private static void registerEntityAliases(Map<String, EntityType> entityTypes) {
-        alias(entityTypes, "bogged", "parched");
-        alias(entityTypes, "husk", "camel_husk");
-        alias(entityTypes, "ghast", "happy_ghast", "ghastling");
-        alias(entityTypes, "drowned", "zombie_nautilus", "coral_zombie_nautilus");
-        alias(entityTypes, "iron_golem", "copper_golem");
-        alias(entityTypes, "breeze", "nautilus");
-    }
-
-    private static void registerPotionAliases(Map<String, PotionEffectType> potions) {
-        alias(potions, "bad_omen", "raid_omen", "trial_omen");
-        alias(potions, "wind_charged", "wind_charge");
-    }
-
-    private static void registerEnchantmentAliases(Map<String, Enchantment> enchantments) {
-        alias(enchantments, "breach", "lunge");
     }
 
     static {
@@ -417,7 +394,6 @@ public class VerUtil {
             if (key == null) continue;
             enchantments.put(key.toLowerCase(), enchantment);
         }
-        registerEnchantmentAliases(enchantments);
         VerUtil.enchantment = new VerEnumValues<>(enchantments, Enchantment.LUCK);
         Scheduler.runTask(false, () -> {
             Map<String, Enchantment> newerEnchantments = new HashMap<>();
@@ -427,7 +403,6 @@ public class VerUtil {
                 if (key == null) continue;
                 newerEnchantments.put(key.toLowerCase(), enchantment);
             }
-            registerEnchantmentAliases(newerEnchantments);
             VerUtil.enchantment = new VerEnumValues<>(newerEnchantments, Enchantment.LUCK);
         });
 
@@ -436,7 +411,6 @@ public class VerUtil {
             if (entityType == null) continue;
             entityTypes.put(entityType.name().toLowerCase(), entityType);
         }
-        registerEntityAliases(entityTypes);
         VerUtil.entityTypes = new VerEnumValues<>(entityTypes, EntityType.UNKNOWN);
 
         Map<String, PotionEffectType> potions = new HashMap<>();
@@ -444,7 +418,6 @@ public class VerUtil {
             if (potionEffectType == null) continue;
             potions.put(potionEffectType.getName().toLowerCase(), potionEffectType);
         }
-        registerPotionAliases(potions);
         VerUtil.potions = new VerEnumValues<>(potions, PotionEffectType.NIGHT_VISION);
         Scheduler.runTask(false, () -> {
             Map<String, PotionEffectType> newerPotions = new HashMap<>();
@@ -452,7 +425,6 @@ public class VerUtil {
                 if (potionEffectType == null) continue;
                 newerPotions.put(potionEffectType.getName().toLowerCase(), potionEffectType);
             }
-            registerPotionAliases(newerPotions);
             VerUtil.potions = new VerEnumValues<>(newerPotions, PotionEffectType.NIGHT_VISION);
         });
     }

--- a/src/main/java/me/vekster/lightanticheat/version/VerUtil.java
+++ b/src/main/java/me/vekster/lightanticheat/version/VerUtil.java
@@ -394,7 +394,7 @@ public class VerUtil {
             if (key == null) continue;
             enchantments.put(key.toLowerCase(), enchantment);
         }
-        VerUtil.enchantment = new VerEnumValues<>(enchantments, Enchantment.LUCK);
+        VerUtil.enchantment = new VerEnumValues<>(enchantments, Enchantment.LUCK_OF_THE_SEA);
         Scheduler.runTask(false, () -> {
             Map<String, Enchantment> newerEnchantments = new HashMap<>();
             for (Enchantment enchantment : Enchantment.values()) {
@@ -403,7 +403,7 @@ public class VerUtil {
                 if (key == null) continue;
                 newerEnchantments.put(key.toLowerCase(), enchantment);
             }
-            VerUtil.enchantment = new VerEnumValues<>(newerEnchantments, Enchantment.LUCK);
+            VerUtil.enchantment = new VerEnumValues<>(newerEnchantments, Enchantment.LUCK_OF_THE_SEA);
         });
 
         Map<String, EntityType> entityTypes = new HashMap<>();

--- a/src/main/java/me/vekster/lightanticheat/version/identifier/LACVersion.java
+++ b/src/main/java/me/vekster/lightanticheat/version/identifier/LACVersion.java
@@ -14,7 +14,8 @@ public enum LACVersion {
     V1_17(10),
     V1_18(11),
     V1_19(12),
-    V1_20(13);
+    V1_20(13),
+    V1_21(14);
 
     public final int number;
 

--- a/src/main/java/me/vekster/lightanticheat/version/identifier/MinecraftFeatureRegistry.java
+++ b/src/main/java/me/vekster/lightanticheat/version/identifier/MinecraftFeatureRegistry.java
@@ -1,0 +1,40 @@
+package me.vekster.lightanticheat.version.identifier;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * String-key registry for content introduced in Minecraft 1.21+.
+ * Keys are lowercase Bukkit enum-style names and are used as compatibility hints
+ * for future checks and integrations.
+ */
+public final class MinecraftFeatureRegistry {
+
+    private MinecraftFeatureRegistry() {
+    }
+
+    public static final Set<String> MC_121_MOBS = unmodifiable(
+            "breeze", "bogged", "creaking", "copper_golem", "nautilus",
+            "zombie_nautilus", "coral_zombie_nautilus", "camel_husk", "parched",
+            "happy_ghast", "ghastling"
+    );
+
+    public static final Set<String> MC_121_MACE_AND_SPEAR_ENCHANTS = unmodifiable(
+            "density", "breach", "wind_burst", "lunge"
+    );
+
+    public static final Set<String> MC_121_STATUS_EFFECTS = unmodifiable(
+            "infested", "oozing", "weaving", "wind_charged", "raid_omen", "trial_omen",
+            "breath_of_the_nautilus"
+    );
+
+    public static final Set<String> MC_121_WORLD_FEATURES = unmodifiable(
+            "trial_chambers", "pale_garden", "fallen_trees"
+    );
+
+    private static Set<String> unmodifiable(String... values) {
+        return Collections.unmodifiableSet(new HashSet<>(Arrays.asList(values)));
+    }
+}

--- a/src/main/java/me/vekster/lightanticheat/version/identifier/VerIdentifier.java
+++ b/src/main/java/me/vekster/lightanticheat/version/identifier/VerIdentifier.java
@@ -33,10 +33,12 @@ public class VerIdentifier {
         else if (version.startsWith("v1_17"))
             serverVersion = LACVersion.V1_17;
         else if (version.startsWith("v1_18"))
-            serverVersion = LACVersion.V1_17;
+            serverVersion = LACVersion.V1_18;
         else if (version.startsWith("v1_19"))
             serverVersion = LACVersion.V1_19;
-        else serverVersion = LACVersion.V1_20;
+        else if (version.startsWith("v1_20"))
+            serverVersion = LACVersion.V1_20;
+        else serverVersion = LACVersion.V1_21;
         return serverVersion;
     }
 

--- a/src/main/java/me/vekster/lightanticheat/version/identifier/VerIdentifier.java
+++ b/src/main/java/me/vekster/lightanticheat/version/identifier/VerIdentifier.java
@@ -5,6 +5,7 @@ import org.bukkit.Bukkit;
 public class VerIdentifier {
 
     private static LACVersion serverVersion = null;
+    private static int[] minecraftVersion = null;
 
     public static LACVersion getVersion() {
         if (serverVersion != null)
@@ -40,6 +41,39 @@ public class VerIdentifier {
             serverVersion = LACVersion.V1_20;
         else serverVersion = LACVersion.V1_21;
         return serverVersion;
+    }
+
+    public static int[] getMinecraftVersion() {
+        if (minecraftVersion != null)
+            return minecraftVersion.clone();
+
+        String bukkitVersion = Bukkit.getBukkitVersion();
+        String numeric = bukkitVersion.split("-")[0];
+        String[] parts = numeric.split("\\.");
+
+        int major = parts.length > 0 ? parseVersionPart(parts[0]) : 0;
+        int minor = parts.length > 1 ? parseVersionPart(parts[1]) : 0;
+        int patch = parts.length > 2 ? parseVersionPart(parts[2]) : 0;
+
+        minecraftVersion = new int[] { major, minor, patch };
+        return minecraftVersion.clone();
+    }
+
+    public static boolean isAtLeastMinecraft(int major, int minor, int patch) {
+        int[] current = getMinecraftVersion();
+        if (current[0] != major)
+            return current[0] > major;
+        if (current[1] != minor)
+            return current[1] > minor;
+        return current[2] >= patch;
+    }
+
+    private static int parseVersionPart(String part) {
+        try {
+            return Integer.parseInt(part);
+        } catch (NumberFormatException ignored) {
+            return 0;
+        }
     }
 
 }


### PR DESCRIPTION
This repository updates LightAntiCheat to the latest Minecraft: Java Edition version (1.21.11) and fixes multiple issues: 
https://github.com/tiredvekster/LightAntiCheat/issues/69
https://github.com/tiredvekster/LightAntiCheat/issues/68 
https://github.com/tiredvekster/LightAntiCheat/issues/64 
https://github.com/tiredvekster/LightAntiCheat/issues/60 
https://github.com/tiredvekster/LightAntiCheat/issues/59 
https://github.com/tiredvekster/LightAntiCheat/issues/56 
https://github.com/tiredvekster/LightAntiCheat/issues/46 
https://github.com/tiredvekster/LightAntiCheat/issues/38 
https://github.com/tiredvekster/LightAntiCheat/issues/43 
https://github.com/tiredvekster/LightAntiCheat/issues/32 
https://github.com/tiredvekster/LightAntiCheat/issues/19 
https://github.com/tiredvekster/LightAntiCheat/issues/16 
https://github.com/tiredvekster/LightAntiCheat/issues/17 
https://github.com/tiredvekster/LightAntiCheat/issues/15 
https://github.com/tiredvekster/LightAntiCheat/issues/12
!!! WARNING !!!
**This is a temporary solution and we need to wait for updates from the main developer.**
This repository / pull request is vibecoded and was written with the help of AI.
There is no support, and it is not recommended for production use.
Tested on: Canvas 1.21.11